### PR TITLE
refactor UidCoreClient and add informative logging

### DIFF
--- a/src/main/java/com/uid2/shared/attest/AttestationToken.java
+++ b/src/main/java/com/uid2/shared/attest/AttestationToken.java
@@ -43,6 +43,7 @@ import java.util.Random;
 public class AttestationToken {
     private static final Logger LOGGER = LoggerFactory.getLogger(AttestationToken.class);
     private static final String Algorithm = "AES/CBC/PKCS5Padding";
+    private static final String INVALID_USER_TOKEN = "invalid";
 
     private final String userToken;
     private final long expiresAt;
@@ -132,13 +133,13 @@ public class AttestationToken {
     }
 
     private static AttestationToken Failed() {
-        return new AttestationToken("invalid", 0L, 0L, false);
+        return new AttestationToken(INVALID_USER_TOKEN, 0L, 0L, false);
     }
 
     @Override
     public String toString() {
         return "AttestationToken{" +
-                "userToken=" + userToken +
+                "userToken=" + (userToken.equals(INVALID_USER_TOKEN) ? INVALID_USER_TOKEN : "********") +
                 ", expiresAt=" + expiresAt +
                 ", nonce=" + nonce +
                 '}';

--- a/src/main/java/com/uid2/shared/middleware/AttestationMiddleware.java
+++ b/src/main/java/com/uid2/shared/middleware/AttestationMiddleware.java
@@ -26,9 +26,12 @@ package com.uid2.shared.middleware;
 import com.uid2.shared.attest.IAttestationTokenService;
 import com.uid2.shared.auth.*;
 import io.vertx.core.Handler;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.RoutingContext;
 
 public class AttestationMiddleware {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AttestationMiddleware.class);
 
     private final IAttestationTokenService tokenService;
 

--- a/src/main/java/com/uid2/shared/store/ISaltProvider.java
+++ b/src/main/java/com/uid2/shared/store/ISaltProvider.java
@@ -61,7 +61,6 @@ public interface ISaltProvider {
 
         @Override
         public int getIndex(byte[] shaBytes, int totalEntries) {
-            LOGGER.warn("slow mod-based indexer is used, this is intended only for unit test");
             int hash = ((shaBytes[0] & 0xFF) << 12) | ((shaBytes[1] & 0xFF) << 4) | ((shaBytes[2] & 0xFF) & 0xF);
             return hash % totalEntries;
         }


### PR DESCRIPTION
Changes
- attestation process in UidCoreClient is separated in multiple helper functions without a good reason
- redact AttestationToken.ToString in case some exceptions print out values and call ToString implicitly
- attestation should always notify response status watcher, including the first one