### PR TITLE
update attestation token to use AES/GCM/NoPadding

### DIFF
--- a/src/main/java/com/uid2/shared/attest/AttestationTokenService.java
+++ b/src/main/java/com/uid2/shared/attest/AttestationTokenService.java
@@ -12,9 +12,9 @@ public class AttestationTokenService implements IAttestationTokenService {
         this.encryptionSalt = encryptionSalt;
     }
 
-    public String createToken(String userToken, Instant expiresAt, String key, String salt) {
+    public String createToken(String userToken, Instant expiresAt) {
         AttestationToken attToken = new AttestationToken(userToken, expiresAt);
-        return attToken.encode(key, salt);
+        return attToken.encode(encryptionKey, encryptionSalt);
     }
 
     public boolean validateToken(String userToken, String attestationToken) {

--- a/src/main/java/com/uid2/shared/attest/IAttestationTokenService.java
+++ b/src/main/java/com/uid2/shared/attest/IAttestationTokenService.java
@@ -3,6 +3,6 @@ package com.uid2.shared.attest;
 import java.time.Instant;
 
 public interface IAttestationTokenService {
-    String createToken(String userToken, Instant expiresAt, String key, String salt);
+    String createToken(String userToken, Instant expiresAt);
     boolean validateToken(String userToken, String attestationToken);
 }

--- a/src/test/java/com/uid2/shared/secure/AttestationTokenTest.java
+++ b/src/test/java/com/uid2/shared/secure/AttestationTokenTest.java
@@ -1,0 +1,44 @@
+package com.uid2.shared.secure;
+
+import com.uid2.shared.attest.AttestationToken;
+import com.uid2.shared.attest.AttestationTokenService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+public class AttestationTokenTest {
+    private static final String ENCRYPTION_KEY = "attestation-token-secret";
+    private static final String SALT = "attestation-token-salt";
+    @Test
+    public void testAttestationTokenPlain() {
+        final AttestationTokenService ats = new AttestationTokenService(ENCRYPTION_KEY, SALT);
+        final String attestationToken = ats.createToken(
+                "userToken",
+                Instant.now().plus(1, ChronoUnit.HOURS));
+        Assertions.assertTrue(ats.validateToken("userToken", attestationToken));
+    }
+
+    @Test
+    public void testAttestationTokenBackwardsCompatible() {
+        // this test should deprecate together with old encode methods
+        final AttestationTokenService ats = new AttestationTokenService(ENCRYPTION_KEY, SALT);
+        final String attestationToken = new AttestationToken(
+                    "userToken",
+                    Instant.now().plus(1, ChronoUnit.HOURS)
+                    ).encode(ENCRYPTION_KEY, SALT);
+        Assertions.assertTrue(ats.validateToken("userToken", attestationToken));
+    }
+
+    @Test
+    public void testAttestationTokenNew() {
+        // this test should deprecate together with old encode methods
+        final AttestationTokenService ats = new AttestationTokenService(ENCRYPTION_KEY, SALT);
+        final String attestationToken = new AttestationToken(
+                "userToken",
+                Instant.now().plus(1, ChronoUnit.HOURS)
+        ).encodeNew(ENCRYPTION_KEY, SALT);
+        Assertions.assertTrue(ats.validateToken("userToken", attestationToken));
+    }
+}


### PR DESCRIPTION
Update attestation token encryption algorithm to AES/GCM/NoPadding - first half (UID2-538)

Reason for implementing backward compatibility: optout does not generate new ATs but needs to validate ATs generated by UID Core.

After making sure optout and core have both been updated to new algorithm we will clean up the code.