### PR TITLE
Sort the roles in alphabetic order

### DIFF
--- a/src/main/java/com/uid2/shared/auth/OperatorKey.java
+++ b/src/main/java/com/uid2/shared/auth/OperatorKey.java
@@ -52,8 +52,7 @@ public class OperatorKey implements IRoleAuthorizable<Role> {
         this.created = created;
         this.disabled = disabled;
         this.siteId = siteId;
-        roles.add(Role.OPERATOR);
-        this.roles = Collections.unmodifiableSet(roles);
+        this.roles = this.reorderAndAddDefaultRole(roles);
         this.operatorType = defaultOperatorType;
     }
 
@@ -65,8 +64,7 @@ public class OperatorKey implements IRoleAuthorizable<Role> {
         this.created = created;
         this.disabled = disabled;
         this.siteId = siteId;
-        roles.add(Role.OPERATOR);
-        this.roles = Collections.unmodifiableSet(roles);
+        this.roles = this.reorderAndAddDefaultRole(roles);
         this.operatorType = operatorType;
     }
 
@@ -86,11 +84,10 @@ public class OperatorKey implements IRoleAuthorizable<Role> {
     public void setOperatorType(OperatorType type) { this.operatorType = type; }
     public void setSiteId(Integer siteId) { this.siteId = siteId; }
     public void setRoles(Set<Role> roles) {
-        roles.add(Role.OPERATOR);
-        this.roles = Collections.unmodifiableSet(roles);
+        this.roles = this.reorderAndAddDefaultRole(roles);
     }
     public OperatorKey withRoles(Set<Role> roles) { setRoles(roles); return this; }
-    public OperatorKey withRoles(Role... roles) { setRoles(new HashSet<>(Arrays.asList(roles))); return this; }
+    public OperatorKey withRoles(Role... roles) { setRoles(new TreeSet<>(Arrays.asList(roles))); return this; }
     public static OperatorKey valueOf(JsonObject json) {
         return new OperatorKey(
                 json.getString("key"),
@@ -103,6 +100,13 @@ public class OperatorKey implements IRoleAuthorizable<Role> {
                 Roles.getRoles(Role.class, json),
                 OperatorType.valueOf(json.getString("operator_type", defaultOperatorType.toString()))
                 );
+    }
+
+    private Set<Role> reorderAndAddDefaultRole(Set<Role> roles) {
+        Set<Role> newRoles = roles != null ? new TreeSet<>(roles) : new TreeSet<>();
+        newRoles.add(Role.OPERATOR);
+        newRoles.removeIf(Objects::isNull);
+        return Collections.unmodifiableSet(newRoles);
     }
 
     @Override

--- a/src/main/java/com/uid2/shared/auth/Roles.java
+++ b/src/main/java/com/uid2/shared/auth/Roles.java
@@ -10,9 +10,8 @@ import java.util.stream.Collectors;
 
 public class Roles {
     public static <T extends Enum<T>> Set<T> getRoles(Class<T> type, JsonObject clientKeyJson) {
-        return clientKeyJson.containsKey("roles")
-                ? getRoles(type, clientKeyJson.getJsonArray("roles"))
-                : null;
+        JsonArray rolesArr = clientKeyJson.getJsonArray("roles");
+        return rolesArr != null ? getRoles(type, rolesArr) : null;
     }
 
     public static <T extends Enum<T>> Set<T> getRoles(Class<T> type, JsonArray rolesJsonArray) {

--- a/src/main/java/com/uid2/shared/auth/Roles.java
+++ b/src/main/java/com/uid2/shared/auth/Roles.java
@@ -10,7 +10,9 @@ import java.util.stream.Collectors;
 
 public class Roles {
     public static <T extends Enum<T>> Set<T> getRoles(Class<T> type, JsonObject clientKeyJson) {
-        return getRoles(type, clientKeyJson.getJsonArray("roles", new JsonArray()));
+        return clientKeyJson.containsKey("roles")
+                ? getRoles(type, clientKeyJson.getJsonArray("roles"))
+                : null;
     }
 
     public static <T extends Enum<T>> Set<T> getRoles(Class<T> type, JsonArray rolesJsonArray) {

--- a/src/test/java/com/uid2/shared/auth/OperatorKeyTest.java
+++ b/src/test/java/com/uid2/shared/auth/OperatorKeyTest.java
@@ -1,10 +1,13 @@
 package com.uid2.shared.auth;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.HashSet;
 
 public class OperatorKeyTest {
@@ -143,6 +146,22 @@ public class OperatorKeyTest {
     }
 
     @Test
+    public void verifyRolesIsWrittenInAlphabeticalOrder() throws JsonProcessingException {
+        final String expectJson = "{" +
+                "\"key\":\"test-admin-key\"," +
+                "\"name\":\"admin@uid2.com\"," +
+                "\"contact\":\"admin@uid2.com\"," +
+                "\"protocol\":\"protocol1\"," +
+                "\"created\":1617149276," +
+                "\"disabled\":false," +
+                "\"roles\":[\"OPERATOR\",\"OPTOUT\"]," +
+                "\"site_id\":1," +
+                "\"operator_type\":\"PRIVATE\"" +
+                "}";
+        OperatorKey k = new OperatorKey("test-admin-key", "admin@uid2.com", "admin@uid2.com", "protocol1", 1617149276, false, 1, new HashSet<>(Arrays.asList(Role.OPTOUT, Role.OPERATOR)));
+        ObjectMapper objectMapper = new ObjectMapper();
+        Assert.assertEquals(expectJson, objectMapper.writeValueAsString(k));
+    }
     public void verifyIsPublicOperatorFlagIsOptionalForBackwardsCompatibility() {
         final String testJson = "    {\n" +
                 "        \"key\": \"test-admin-key\",\n" +
@@ -204,11 +223,11 @@ public class OperatorKeyTest {
         Assert.assertTrue(k1.getOperatorType() == OperatorType.PRIVATE);
         OperatorKey k2 = new OperatorKey("key2", "name2", "contact2", "protocol2", 2, true, 2);
         Assert.assertTrue(k2.getOperatorType() == OperatorType.PRIVATE);
-        OperatorKey k3 = new OperatorKey("key3", "name3", "contact3", "protocol3", 3, true, 3,  new HashSet<Role>());
+        OperatorKey k3 = new OperatorKey("key3", "name3", "contact3", "protocol3", 3, true, 3,  null);
         Assert.assertTrue(k3.getOperatorType() == OperatorType.PRIVATE);
-        OperatorKey k4 = new OperatorKey("key4", "name4", "contact4", "protocol4", 4, true, 4,  new HashSet<Role>(), OperatorType.PUBLIC);
+        OperatorKey k4 = new OperatorKey("key4", "name4", "contact4", "protocol4", 4, true, 4,  null, OperatorType.PUBLIC);
         Assert.assertTrue(k4.getOperatorType() == OperatorType.PUBLIC);
-        OperatorKey k5 = new OperatorKey("key5", "name5", "contact5", "protocol5", 5, true, 5,  new HashSet<Role>(), OperatorType.PRIVATE);
+        OperatorKey k5 = new OperatorKey("key5", "name5", "contact5", "protocol5", 5, true, 5,  null, OperatorType.PRIVATE);
         Assert.assertTrue(k5.getOperatorType() == OperatorType.PRIVATE);
     }
 }


### PR DESCRIPTION
Changes:
- Sort roles in alphabetic order to avoid unnecessary changes to the role list
- Fix nullpointerexception when constructor take null as roles
- Check the existence of roles key in the JSON object first rather than always create an empty object as default value

