### PR TITLE
Wrap attestation token lifetime into atService for better encapsulation

### DIFF
--- a/src/main/java/com/uid2/shared/attest/AttestationToken.java
+++ b/src/main/java/com/uid2/shared/attest/AttestationToken.java
@@ -97,6 +97,10 @@ public class AttestationToken {
         return this.isValid && this.userToken.equals(userToken) && this.expiresAt > Instant.now().getEpochSecond();
     }
 
+    public Instant getExpiresAt() {
+        return Instant.ofEpochSecond(expiresAt);
+    }
+
     private static SecretKey getKeyFromPassword(String paraphrase, String salt)
             throws NoSuchAlgorithmException, InvalidKeySpecException
     {

--- a/src/main/java/com/uid2/shared/attest/AttestationTokenService.java
+++ b/src/main/java/com/uid2/shared/attest/AttestationTokenService.java
@@ -1,22 +1,42 @@
 package com.uid2.shared.attest;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 public class AttestationTokenService implements IAttestationTokenService {
 
     private final String encryptionKey;
     private final String encryptionSalt;
+    private final long expiresAfterSeconds;
 
+    @Deprecated
     public AttestationTokenService(String encryptionKey, String encryptionSalt) {
         this.encryptionKey = encryptionKey;
         this.encryptionSalt = encryptionSalt;
+        this.expiresAfterSeconds = 2 * 3600; // 2 hours;
     }
 
+    public AttestationTokenService(String encryptionKey, String encryptionSalt, long expiresAfterSeconds) {
+        this.encryptionKey = encryptionKey;
+        this.encryptionSalt = encryptionSalt;
+        this.expiresAfterSeconds = expiresAfterSeconds;
+    }
+
+    @Override
+    public String createToken(String userToken) {
+        Instant expiresAt = Instant.now().plus(this.expiresAfterSeconds, ChronoUnit.SECONDS);
+        AttestationToken attToken = new AttestationToken(userToken, expiresAt);
+        return attToken.encode(encryptionKey, encryptionSalt);
+    }
+
+    @Deprecated
+    @Override
     public String createToken(String userToken, Instant expiresAt) {
         AttestationToken attToken = new AttestationToken(userToken, expiresAt);
         return attToken.encode(encryptionKey, encryptionSalt);
     }
 
+    @Override
     public boolean validateToken(String userToken, String attestationToken) {
         AttestationToken decrypted = AttestationToken.fromEncrypted(
             attestationToken,

--- a/src/main/java/com/uid2/shared/attest/IAttestationTokenService.java
+++ b/src/main/java/com/uid2/shared/attest/IAttestationTokenService.java
@@ -3,6 +3,27 @@ package com.uid2.shared.attest;
 import java.time.Instant;
 
 public interface IAttestationTokenService {
+    /**
+     * Create attestation token from user token
+     * @param userToken
+     * @return attestation token
+     */
+    String createToken(String userToken);
+
+    /**
+     * Create attestation token from user token
+     * @param userToken
+     * @param expiresAt
+     * @return
+     */
+    @Deprecated
     String createToken(String userToken, Instant expiresAt);
+
+    /**
+     * Validate if attestation is generated from the user token provided
+     * @param userToken
+     * @param attestationToken
+     * @return if the credential matches
+     */
     boolean validateToken(String userToken, String attestationToken);
 }

--- a/src/test/java/com/uid2/shared/secure/AttestationTokenTest.java
+++ b/src/test/java/com/uid2/shared/secure/AttestationTokenTest.java
@@ -1,5 +1,6 @@
 package com.uid2.shared.secure;
 
+import com.uid2.shared.attest.AttestationToken;
 import com.uid2.shared.attest.AttestationTokenService;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -50,5 +51,20 @@ public class AttestationTokenTest {
                 Instant.now().plus(1, ChronoUnit.HOURS));
         final String badAttestationToken = attestationToken + "-hoho";
         Assertions.assertFalse(ats.validateToken("userToken", badAttestationToken));
+    }
+
+    @Test
+    public void testAttestationTokenNew() {
+        final long lifetime = 1800;
+        final Instant expiryLowerBound = Instant.now().plus(lifetime - 60, ChronoUnit.SECONDS);
+        final Instant expiryUpperBound = Instant.now().plus(lifetime + 300, ChronoUnit.SECONDS);
+        final AttestationTokenService ats = new AttestationTokenService(ENCRYPTION_KEY, SALT, lifetime);
+
+        final String attestationToken = ats.createToken("userToken");
+        Assertions.assertTrue(ats.validateToken("userToken", attestationToken));
+
+        final AttestationToken reconstructToken = AttestationToken.fromEncrypted(attestationToken, ENCRYPTION_KEY, SALT);
+        Assertions.assertTrue(reconstructToken.getExpiresAt().isAfter(expiryLowerBound));
+        Assertions.assertTrue(reconstructToken.getExpiresAt().isBefore(expiryUpperBound));
     }
 }

--- a/src/test/java/com/uid2/shared/secure/AttestationTokenTest.java
+++ b/src/test/java/com/uid2/shared/secure/AttestationTokenTest.java
@@ -56,8 +56,8 @@ public class AttestationTokenTest {
     @Test
     public void testAttestationTokenNew() {
         final long lifetime = 1800;
-        final Instant expiryLowerBound = Instant.now().plus(lifetime - 60, ChronoUnit.SECONDS);
-        final Instant expiryUpperBound = Instant.now().plus(lifetime + 300, ChronoUnit.SECONDS);
+        final Instant expiryLowerBound = Instant.now().plusSeconds(lifetime - 60);
+        final Instant expiryUpperBound = Instant.now().plusSeconds(lifetime + 300);
         final AttestationTokenService ats = new AttestationTokenService(ENCRYPTION_KEY, SALT, lifetime);
 
         final String attestationToken = ats.createToken("userToken");
@@ -66,5 +66,12 @@ public class AttestationTokenTest {
         final AttestationToken reconstructToken = AttestationToken.fromEncrypted(attestationToken, ENCRYPTION_KEY, SALT);
         Assertions.assertTrue(reconstructToken.getExpiresAt().isAfter(expiryLowerBound));
         Assertions.assertTrue(reconstructToken.getExpiresAt().isBefore(expiryUpperBound));
+    }
+
+    @Test
+    public void testAttestationTokenExpiry() {
+        Assertions.assertFalse(new AttestationToken(
+                "hello",
+                Instant.now().minusSeconds(1)).validate("hello"));
     }
 }


### PR DESCRIPTION
AttestationTokenService requires a `expiresAt` parameter when generating token, which should be kept internal because the caller (UIDCoreVerticle) shouldn't care about the lifetime. 