### PR TITLE
add tomestone flag bit into OptOutEntry to avoid major changes

### DIFF
--- a/src/main/java/com/uid2/shared/optout/OptOutPartition.java
+++ b/src/main/java/com/uid2/shared/optout/OptOutPartition.java
@@ -21,6 +21,11 @@ public class OptOutPartition extends OptOutCollection {
             return -1;
         }
 
+        if (getTombstoneByIndex(entryIndex)) {
+            // this user optout has been marked for deletion (user opt-in)
+            return -1;
+        }
+
         return getTimestampByIndex(entryIndex);
     }
 
@@ -63,5 +68,9 @@ public class OptOutPartition extends OptOutCollection {
     private long getTimestampByIndex(int entryIndex) {
         // start byte index is calculated from itemIndex and optout entry size
         return OptOutEntry.parseTimestamp(this.store, entryIndex * OptOutConst.EntrySize);
+    }
+
+    private boolean getTombstoneByIndex(int entryIndex) {
+        return OptOutEntry.parseTombstone(this.store, entryIndex * OptOutConst.EntrySize);
     }
 }

--- a/src/test/java/com/uid2/shared/optout/OptOutEntryTest.java
+++ b/src/test/java/com/uid2/shared/optout/OptOutEntryTest.java
@@ -22,6 +22,7 @@ public class OptOutEntryTest {
         Assert.assertArrayEquals(idHash, entry.identityHash);
         Assert.assertArrayEquals(adsId, entry.advertisingId);
         Assert.assertEquals(0x56555453525150l, entry.timestamp);
+        Assert.assertFalse(entry.isTombstone);
     }
 
     @Test
@@ -45,6 +46,7 @@ public class OptOutEntryTest {
         Assert.assertArrayEquals(idHash, entry.identityHash);
         Assert.assertArrayEquals(expectedAdsId, entry.advertisingId);
         Assert.assertEquals(0x56555453525150l, entry.timestamp);
+        Assert.assertFalse(entry.isTombstone);
     }
 
     @Test
@@ -69,6 +71,7 @@ public class OptOutEntryTest {
         Assert.assertArrayEquals(idHash, entry.identityHash);
         Assert.assertArrayEquals(expectedAdsId, entry.advertisingId);
         Assert.assertEquals(0x56555453525150l, entry.timestamp);
+        Assert.assertFalse(entry.isTombstone);
     }
 
     @Test
@@ -113,6 +116,7 @@ public class OptOutEntryTest {
         Assert.assertArrayEquals(idHash, entry.identityHash);
         Assert.assertArrayEquals(expectedAdsId, entry.advertisingId);
         Assert.assertEquals(newTimestamp, entry.timestamp);
+        Assert.assertFalse(entry.isTombstone);
     }
 
     @Test
@@ -124,13 +128,14 @@ public class OptOutEntryTest {
 
         final int offset = 12;
         final byte[] records = new byte[offset + OptOutConst.EntrySize];
-        final OptOutEntry input = new OptOutEntry(idHash, adsId, timestamp);
+        final OptOutEntry input = new OptOutEntry(idHash, adsId, timestamp, false);
         input.copyToByteArray(records, offset);
 
         final OptOutEntry entry = OptOutEntry.parse(records, 12);
         Assert.assertArrayEquals(idHash, entry.identityHash);
         Assert.assertArrayEquals(adsId, entry.advertisingId);
         Assert.assertEquals(0x56555453525150l, entry.timestamp);
+        Assert.assertFalse(entry.isTombstone);
     }
 
     @Test
@@ -142,13 +147,14 @@ public class OptOutEntryTest {
 
         final int offset = 12;
         final byte[] records = new byte[offset + OptOutConst.EntrySize];
-        final OptOutEntry input = new OptOutEntry(idHash, adsId, timestamp);
+        final OptOutEntry input = new OptOutEntry(idHash, adsId, timestamp, false);
         input.copyToByteArray(records, offset);
 
         final OptOutEntry entry = OptOutEntry.parse(records, 12);
         Assert.assertArrayEquals(idHash, entry.identityHash);
         Assert.assertArrayEquals(adsId, entry.advertisingId);
         Assert.assertEquals(0x56555453525150l, entry.timestamp);
+        Assert.assertFalse(entry.isTombstone);
     }
 
     @Test
@@ -159,11 +165,37 @@ public class OptOutEntryTest {
         final long timestamp = 0x56555453525150l;
 
         ByteBuffer buffer = ByteBuffer.allocate(OptOutConst.EntrySize);
-        OptOutEntry.writeTo(buffer, idHash, adsId, timestamp);
+        OptOutEntry.writeTo(buffer, idHash, adsId, timestamp, false);
 
         final OptOutEntry entry = OptOutEntry.parse(buffer.array(), 0);
         Assert.assertArrayEquals(idHash, entry.identityHash);
         Assert.assertArrayEquals(adsId, entry.advertisingId);
         Assert.assertEquals(0x56555453525150l, entry.timestamp);
+        Assert.assertFalse(entry.isTombstone);
+    }
+
+    @Test
+    public void checkTombstone() {
+        final int offset = 12;
+        final byte[] idHash = OptOutUtils.hexToByteArray("101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f");
+        final byte[] adsId = OptOutUtils.hexToByteArray("303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f");
+        final byte[] timestamp = OptOutUtils.hexToByteArray("50515253545556");
+        final byte metadata = 0x74;
+
+        final byte[] records = new byte[offset + OptOutConst.EntrySize];
+        System.arraycopy(idHash, 0, records, offset, OptOutConst.Sha256Bytes);
+        System.arraycopy(adsId, 0, records, offset + OptOutConst.Sha256Bytes, OptOutConst.Sha256Bytes);
+        System.arraycopy(timestamp, 0, records, offset + OptOutConst.Sha256Bytes * 2, Long.BYTES - 1);
+        records[offset + OptOutConst.EntrySize - 1] = metadata;
+
+        final byte[] expectedAdsId = new byte[33];
+        expectedAdsId[0] = 0x14;
+        System.arraycopy(adsId, 0, expectedAdsId, 1, OptOutConst.Sha256Bytes);
+
+        final OptOutEntry entry = OptOutEntry.parse(records, offset);
+        Assert.assertArrayEquals(idHash, entry.identityHash);
+        Assert.assertArrayEquals(expectedAdsId, entry.advertisingId);
+        Assert.assertEquals(0x56555453525150l, entry.timestamp);
+        Assert.assertTrue(entry.isTombstone);
     }
 }


### PR DESCRIPTION
Use 6th bit (from low) in the metadata byte to indicate user opt-in. This keeps all the data pipeline intact as we are not adding new record types. Only change required from consumer is to check that bit from the opt out record found.