### PR TITLE
Restore AesCbc and AesGcm Helper Functions to Support Old and New Operator

### DIFF
--- a/src/main/java/com/uid2/shared/encryption/AesCbc.java
+++ b/src/main/java/com/uid2/shared/encryption/AesCbc.java
@@ -16,11 +16,7 @@ public class AesCbc {
     private static final String cipherScheme = "AES/CBC/PKCS5Padding";
 
     public static EncryptedPayload encrypt(byte[] b, KeysetKey key) {
-        try {
-            return encrypt(b, key.getKeyBytes(), key.getKeyIdentifier());
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to Encrypt", e);
-        }
+        return encrypt(b, key.getKeyBytes(), key.getKeyIdentifier());
     }
 
     private static EncryptedPayload encrypt(byte[] b, byte[] secretBytes, KeyIdentifier keyIdentifier) {
@@ -38,20 +34,11 @@ public class AesCbc {
     }
 
     public static EncryptedPayload encrypt(String s, KeysetKey key) {
-        try {
-            return encrypt(s.getBytes(StandardCharsets.UTF_8), key.getKeyBytes(), key.getKeyIdentifier());
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to Encrypt", e);
-        }
+        return encrypt(s.getBytes(StandardCharsets.UTF_8), key.getKeyBytes(), key.getKeyIdentifier());
     }
 
     public static byte[] decrypt(byte[] encryptedBytes, KeysetKey key) {
-        try {
-            final SecretKey k = new SecretKeySpec(key.getKeyBytes(), "AES");
-            return decrypt(encryptedBytes, k);
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to Decrypt", e);
-        }
+        return decrypt(encryptedBytes, new SecretKeySpec(key.getKeyBytes(), "AES"));
     }
 
     public static byte[] decrypt(byte[] encryptedBytes, SecretKey key) {
@@ -65,29 +52,15 @@ public class AesCbc {
         }
     }
 
-    // TODO: after KeySets fully migrated, below APIs shall be removed.
     public static EncryptedPayload encrypt(byte[] b, EncryptionKey key) {
-        try {
-            return encrypt(b, key.getKeyBytes(), key.getKeyIdentifier());
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to Encrypt", e);
-        }
+        return encrypt(b, key.getKeyBytes(), key.getKeyIdentifier());
     }
 
     public static EncryptedPayload encrypt(String s, EncryptionKey key) {
-        try {
-            return encrypt(s.getBytes(StandardCharsets.UTF_8), key.getKeyBytes(), key.getKeyIdentifier());
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to Encrypt", e);
-        }
+        return encrypt(s.getBytes(StandardCharsets.UTF_8), key.getKeyBytes(), key.getKeyIdentifier());
     }
 
     public static byte[] decrypt(byte[] encryptedBytes, EncryptionKey key) {
-        try {
-            final SecretKey k = new SecretKeySpec(key.getKeyBytes(), "AES");
-            return decrypt(encryptedBytes, k);
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to Decrypt", e);
-        }
+        return decrypt(encryptedBytes, new SecretKeySpec(key.getKeyBytes(), "AES"));
     }
 }

--- a/src/main/java/com/uid2/shared/encryption/AesCbc.java
+++ b/src/main/java/com/uid2/shared/encryption/AesCbc.java
@@ -2,6 +2,7 @@ package com.uid2.shared.encryption;
 
 import com.uid2.shared.model.EncryptedPayload;
 import com.uid2.shared.model.EncryptionKey;
+import com.uid2.shared.model.KeyIdentifier;
 import com.uid2.shared.model.KeysetKey;
 import io.vertx.core.buffer.Buffer;
 
@@ -16,13 +17,21 @@ public class AesCbc {
 
     public static EncryptedPayload encrypt(byte[] b, KeysetKey key) {
         try {
-            final SecretKey k = new SecretKeySpec(key.getKeyBytes(), "AES");
+            return encrypt(b, key.getKeyBytes(), key.getKeyIdentifier());
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to Encrypt", e);
+        }
+    }
+
+    private static EncryptedPayload encrypt(byte[] b, byte[] secretBytes, KeyIdentifier keyIdentifier) {
+        try {
+            final SecretKey k = new SecretKeySpec(secretBytes, "AES");
             final Cipher c = Cipher.getInstance(cipherScheme);
             final byte[] ivBytes = Random.getBytes(16);
             final IvParameterSpec ivParameterSpec = new IvParameterSpec(ivBytes);
             c.init(Cipher.ENCRYPT_MODE, k, ivParameterSpec);
             final byte[] encryptedBytes = c.doFinal(b);
-            return new EncryptedPayload(key.getKeyIdentifier(), Buffer.buffer().appendBytes(ivBytes).appendBytes(encryptedBytes).getBytes());
+            return new EncryptedPayload(keyIdentifier, Buffer.buffer().appendBytes(ivBytes).appendBytes(encryptedBytes).getBytes());
         } catch (Exception e) {
             throw new RuntimeException("Unable to Encrypt", e);
         }
@@ -30,7 +39,7 @@ public class AesCbc {
 
     public static EncryptedPayload encrypt(String s, KeysetKey key) {
         try {
-            return encrypt(s.getBytes(StandardCharsets.UTF_8), key);
+            return encrypt(s.getBytes(StandardCharsets.UTF_8), key.getKeyBytes(), key.getKeyIdentifier());
         } catch (Exception e) {
             throw new RuntimeException("Unable to Encrypt", e);
         }
@@ -59,13 +68,7 @@ public class AesCbc {
     // TODO: after KeySets fully migrated, below APIs shall be removed.
     public static EncryptedPayload encrypt(byte[] b, EncryptionKey key) {
         try {
-            final SecretKey k = new SecretKeySpec(key.getKeyBytes(), "AES");
-            final Cipher c = Cipher.getInstance(cipherScheme);
-            final byte[] ivBytes = Random.getBytes(16);
-            final IvParameterSpec ivParameterSpec = new IvParameterSpec(ivBytes);
-            c.init(Cipher.ENCRYPT_MODE, k, ivParameterSpec);
-            final byte[] encryptedBytes = c.doFinal(b);
-            return new EncryptedPayload(key.getKeyIdentifier(), Buffer.buffer().appendBytes(ivBytes).appendBytes(encryptedBytes).getBytes());
+            return encrypt(b, key.getKeyBytes(), key.getKeyIdentifier());
         } catch (Exception e) {
             throw new RuntimeException("Unable to Encrypt", e);
         }
@@ -73,7 +76,7 @@ public class AesCbc {
 
     public static EncryptedPayload encrypt(String s, EncryptionKey key) {
         try {
-            return encrypt(s.getBytes(StandardCharsets.UTF_8), key);
+            return encrypt(s.getBytes(StandardCharsets.UTF_8), key.getKeyBytes(), key.getKeyIdentifier());
         } catch (Exception e) {
             throw new RuntimeException("Unable to Encrypt", e);
         }

--- a/src/main/java/com/uid2/shared/encryption/AesCbc.java
+++ b/src/main/java/com/uid2/shared/encryption/AesCbc.java
@@ -1,6 +1,7 @@
 package com.uid2.shared.encryption;
 
 import com.uid2.shared.model.EncryptedPayload;
+import com.uid2.shared.model.EncryptionKey;
 import com.uid2.shared.model.KeysetKey;
 import io.vertx.core.buffer.Buffer;
 
@@ -50,6 +51,38 @@ public class AesCbc {
             final Cipher c = Cipher.getInstance(cipherScheme);
             c.init(Cipher.DECRYPT_MODE, key, iv);
             return c.doFinal(encryptedBytes, 16, encryptedBytes.length - 16);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to Decrypt", e);
+        }
+    }
+
+    // TODO: after KeySets fully migrated, below APIs shall be removed.
+    public static EncryptedPayload encrypt(byte[] b, EncryptionKey key) {
+        try {
+            final SecretKey k = new SecretKeySpec(key.getKeyBytes(), "AES");
+            final Cipher c = Cipher.getInstance(cipherScheme);
+            final byte[] ivBytes = Random.getBytes(16);
+            final IvParameterSpec ivParameterSpec = new IvParameterSpec(ivBytes);
+            c.init(Cipher.ENCRYPT_MODE, k, ivParameterSpec);
+            final byte[] encryptedBytes = c.doFinal(b);
+            return new EncryptedPayload(key.getKeyIdentifier(), Buffer.buffer().appendBytes(ivBytes).appendBytes(encryptedBytes).getBytes());
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to Encrypt", e);
+        }
+    }
+
+    public static EncryptedPayload encrypt(String s, EncryptionKey key) {
+        try {
+            return encrypt(s.getBytes(StandardCharsets.UTF_8), key);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to Encrypt", e);
+        }
+    }
+
+    public static byte[] decrypt(byte[] encryptedBytes, EncryptionKey key) {
+        try {
+            final SecretKey k = new SecretKeySpec(key.getKeyBytes(), "AES");
+            return decrypt(encryptedBytes, k);
         } catch (Exception e) {
             throw new RuntimeException("Unable to Decrypt", e);
         }

--- a/src/main/java/com/uid2/shared/encryption/AesGcm.java
+++ b/src/main/java/com/uid2/shared/encryption/AesGcm.java
@@ -2,6 +2,7 @@ package com.uid2.shared.encryption;
 
 import com.uid2.shared.model.EncryptedPayload;
 import com.uid2.shared.model.EncryptionKey;
+import com.uid2.shared.model.KeyIdentifier;
 import com.uid2.shared.model.KeysetKey;
 import io.vertx.core.buffer.Buffer;
 
@@ -18,8 +19,7 @@ public class AesGcm {
 
     public static EncryptedPayload encrypt(byte[] b, KeysetKey key) {
         try {
-            byte[] encrypted = encrypt(b, key.getKeyBytes());
-            return new EncryptedPayload(key.getKeyIdentifier(), encrypted);
+            return encrypt(b, key.getKeyBytes(), key.getKeyIdentifier());
         } catch (Exception e) {
             throw new RuntimeException("Unable to Encrypt", e);
         }
@@ -27,7 +27,16 @@ public class AesGcm {
 
     public static EncryptedPayload encrypt(String s, KeysetKey key) {
         try {
-            return encrypt(s.getBytes(StandardCharsets.UTF_8), key);
+            return encrypt(s.getBytes(StandardCharsets.UTF_8), key.getKeyBytes(), key.getKeyIdentifier());
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to Encrypt", e);
+        }
+    }
+
+    private static EncryptedPayload encrypt(byte[] b, byte[] secretBytes, KeyIdentifier keyIdentifier) {
+        try {
+            byte[] encrypted = encrypt(b, secretBytes);
+            return new EncryptedPayload(keyIdentifier, encrypted);
         } catch (Exception e) {
             throw new RuntimeException("Unable to Encrypt", e);
         }
@@ -69,8 +78,7 @@ public class AesGcm {
     // TODO: after KeySets fully migrated, below APIs shall be removed.
     public static EncryptedPayload encrypt(byte[] b, EncryptionKey key) {
         try {
-            byte[] encrypted = encrypt(b, key.getKeyBytes());
-            return new EncryptedPayload(key.getKeyIdentifier(), encrypted);
+            return encrypt(b, key.getKeyBytes(), key.getKeyIdentifier());
         } catch (Exception e) {
             throw new RuntimeException("Unable to Encrypt", e);
         }
@@ -78,7 +86,7 @@ public class AesGcm {
 
     public static EncryptedPayload encrypt(String s, EncryptionKey key) {
         try {
-            return encrypt(s.getBytes(StandardCharsets.UTF_8), key);
+            return encrypt(s.getBytes(StandardCharsets.UTF_8), key.getKeyBytes(), key.getKeyIdentifier());
         } catch (Exception e) {
             throw new RuntimeException("Unable to Encrypt", e);
         }

--- a/src/main/java/com/uid2/shared/encryption/AesGcm.java
+++ b/src/main/java/com/uid2/shared/encryption/AesGcm.java
@@ -18,28 +18,15 @@ public class AesGcm {
     public static final int GCM_IV_LENGTH = 12;
 
     public static EncryptedPayload encrypt(byte[] b, KeysetKey key) {
-        try {
-            return encrypt(b, key.getKeyBytes(), key.getKeyIdentifier());
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to Encrypt", e);
-        }
+        return encrypt(b, key.getKeyBytes(), key.getKeyIdentifier());
     }
 
     public static EncryptedPayload encrypt(String s, KeysetKey key) {
-        try {
-            return encrypt(s.getBytes(StandardCharsets.UTF_8), key.getKeyBytes(), key.getKeyIdentifier());
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to Encrypt", e);
-        }
+        return encrypt(s.getBytes(StandardCharsets.UTF_8), key.getKeyBytes(), key.getKeyIdentifier());
     }
 
     private static EncryptedPayload encrypt(byte[] b, byte[] secretBytes, KeyIdentifier keyIdentifier) {
-        try {
-            byte[] encrypted = encrypt(b, secretBytes);
-            return new EncryptedPayload(keyIdentifier, encrypted);
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to Encrypt", e);
-        }
+        return new EncryptedPayload(keyIdentifier, encrypt(b, secretBytes));
     }
 
     public static byte[] encrypt(byte[] b, byte[] secretBytes) {
@@ -56,11 +43,7 @@ public class AesGcm {
     }
 
     public static byte[] decrypt(byte[] encryptedBytes, int offset, KeysetKey key) {
-        try {
-            return decrypt(encryptedBytes, offset, key.getKeyBytes());
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to Decrypt", e);
-        }
+        return decrypt(encryptedBytes, offset, key.getKeyBytes());
     }
 
     public static byte[] decrypt(byte[] encryptedBytes, int offset, byte[] secretBytes) {
@@ -75,28 +58,15 @@ public class AesGcm {
         }
     }
 
-    // TODO: after KeySets fully migrated, below APIs shall be removed.
     public static EncryptedPayload encrypt(byte[] b, EncryptionKey key) {
-        try {
-            return encrypt(b, key.getKeyBytes(), key.getKeyIdentifier());
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to Encrypt", e);
-        }
+        return encrypt(b, key.getKeyBytes(), key.getKeyIdentifier());
     }
 
     public static EncryptedPayload encrypt(String s, EncryptionKey key) {
-        try {
-            return encrypt(s.getBytes(StandardCharsets.UTF_8), key.getKeyBytes(), key.getKeyIdentifier());
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to Encrypt", e);
-        }
+        return encrypt(s.getBytes(StandardCharsets.UTF_8), key.getKeyBytes(), key.getKeyIdentifier());
     }
 
     public static byte[] decrypt(byte[] encryptedBytes, int offset, EncryptionKey key) {
-        try {
-            return decrypt(encryptedBytes, offset, key.getKeyBytes());
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to Decrypt", e);
-        }
+        return decrypt(encryptedBytes, offset, key.getKeyBytes());
     }
 }

--- a/src/main/java/com/uid2/shared/encryption/AesGcm.java
+++ b/src/main/java/com/uid2/shared/encryption/AesGcm.java
@@ -1,6 +1,7 @@
 package com.uid2.shared.encryption;
 
 import com.uid2.shared.model.EncryptedPayload;
+import com.uid2.shared.model.EncryptionKey;
 import com.uid2.shared.model.KeysetKey;
 import io.vertx.core.buffer.Buffer;
 
@@ -60,6 +61,32 @@ public class AesGcm {
             final Cipher c = Cipher.getInstance(cipherScheme);
             c.init(Cipher.DECRYPT_MODE, key, gcmParameterSpec);
             return c.doFinal(encryptedBytes, offset + GCM_IV_LENGTH, encryptedBytes.length - offset - GCM_IV_LENGTH);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to Decrypt", e);
+        }
+    }
+
+    // TODO: after KeySets fully migrated, below APIs shall be removed.
+    public static EncryptedPayload encrypt(byte[] b, EncryptionKey key) {
+        try {
+            byte[] encrypted = encrypt(b, key.getKeyBytes());
+            return new EncryptedPayload(key.getKeyIdentifier(), encrypted);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to Encrypt", e);
+        }
+    }
+
+    public static EncryptedPayload encrypt(String s, EncryptionKey key) {
+        try {
+            return encrypt(s.getBytes(StandardCharsets.UTF_8), key);
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to Encrypt", e);
+        }
+    }
+
+    public static byte[] decrypt(byte[] encryptedBytes, int offset, EncryptionKey key) {
+        try {
+            return decrypt(encryptedBytes, offset, key.getKeyBytes());
         } catch (Exception e) {
             throw new RuntimeException("Unable to Decrypt", e);
         }


### PR DESCRIPTION
We've updated AesCbc and AesGcm helper functions to support new Operator with KeySets. However, during the interim period, we still need old version of these APIs back to support old Operator with Keys and Key_Acls.