### PR TITLE
Remove IdentityScope from required env in PolicyValidator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-shared</artifactId>
-    <version>4.1.5-e1905c8f77</version>
+    <version>4.1.7-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Library for all the shared uid2 operations</description>
     <url>https://github.com/IABTechLab/uid2docs</url>

--- a/src/main/java/com/uid2/shared/secure/GcpOidcAttestationProvider.java
+++ b/src/main/java/com/uid2/shared/secure/GcpOidcAttestationProvider.java
@@ -88,8 +88,7 @@ public class GcpOidcAttestationProvider implements IAttestationProvider{
                     return true;
                 }
             } catch (Exception ex) {
-                // Do not use Warn or Error log here. It could happen as expected during version migration.
-                LOGGER.info("Fail to validator version: " + policyValidator.getVersion() + ", error :" + ex.getMessage());
+                LOGGER.warn("Fail to validator version: " + policyValidator.getVersion() + ", error :" + ex.getMessage());
             }
         }
         return false;

--- a/src/main/java/com/uid2/shared/secure/GcpOidcAttestationProvider.java
+++ b/src/main/java/com/uid2/shared/secure/GcpOidcAttestationProvider.java
@@ -78,17 +78,18 @@ public class GcpOidcAttestationProvider implements IAttestationProvider{
     // Pass as long as one of supported policy validator check pass.
     private boolean Validate(TokenPayload tokenPayload) {
         for (var policyValidator : supportedPolicyValidators) {
-            LOGGER.debug("Validating policy... Validator version: " + policyValidator.getVersion());
+            LOGGER.info("Validating policy... Validator version: " + policyValidator.getVersion());
             try {
                 var enclaveId = policyValidator.validate(tokenPayload);
-                LOGGER.debug("Validator version: " + policyValidator.getVersion() + ", result: " + enclaveId);
+                LOGGER.info("Validator version: " + policyValidator.getVersion() + ", result: " + enclaveId);
 
                 if (allowedEnclaveIds.contains(enclaveId)) {
-                    LOGGER.debug("Successfully attested OIDC against registered enclaves");
+                    LOGGER.info("Successfully attested OIDC against registered enclaves");
                     return true;
                 }
             } catch (Exception ex) {
-                LOGGER.debug("Fail to validator version: " + policyValidator.getVersion() + ", error :" + ex.getMessage());
+                // Do not use Warn or Error log here. It could happen as expected during version migration.
+                LOGGER.info("Fail to validator version: " + policyValidator.getVersion() + ", error :" + ex.getMessage());
             }
         }
         return false;

--- a/src/main/java/com/uid2/shared/secure/gcpoidc/PolicyValidator.java
+++ b/src/main/java/com/uid2/shared/secure/gcpoidc/PolicyValidator.java
@@ -7,6 +7,8 @@ import com.uid2.shared.Utils;
 import com.uid2.shared.secure.AttestationException;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -16,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 public class PolicyValidator implements IPolicyValidator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PolicyValidator.class);
 
     public static final String ENV_ENVIRONMENT = "DEPLOYMENT_ENVIRONMENT";
     public static final String ENV_IDENTITY_SCOPE = "IDENTITY_SCOPE";
@@ -117,6 +120,7 @@ public class PolicyValidator implements IPolicyValidator {
 
     private String generateEnclaveId(boolean isDebugMode, String imageDigest, Environment env) throws AttestationException {
         var str = String.format("%s,%s,%s", getVersion(), isDebugMode, imageDigest);
+        LOGGER.info("Meta used to generate GCP EnclaveId: " + str);
         try {
             return getSha256Base64Encoded(str);
         } catch (NoSuchAlgorithmException e) {

--- a/src/main/java/com/uid2/shared/secure/gcpoidc/PolicyValidator.java
+++ b/src/main/java/com/uid2/shared/secure/gcpoidc/PolicyValidator.java
@@ -21,14 +21,12 @@ public class PolicyValidator implements IPolicyValidator {
     private static final Logger LOGGER = LoggerFactory.getLogger(PolicyValidator.class);
 
     public static final String ENV_ENVIRONMENT = "DEPLOYMENT_ENVIRONMENT";
-    public static final String ENV_IDENTITY_SCOPE = "IDENTITY_SCOPE";
     public static final String ENV_OPERATOR_API_KEY = "API_TOKEN";
     public static final String ENV_CORE_ENDPOINT = "CORE_BASE_URL";
     public static final String ENV_OPT_OUT_ENDPOINT = "OPTOUT_BASE_URL";
 
     private static final List<String> REQUIRED_ENV_OVERRIDES = ImmutableList.of(
             ENV_ENVIRONMENT,
-            ENV_IDENTITY_SCOPE,
             ENV_OPERATOR_API_KEY
     );
 
@@ -92,12 +90,6 @@ public class PolicyValidator implements IPolicyValidator {
         var env = Environment.fromString(envOverridesCopy.get(ENV_ENVIRONMENT));
         if(env == null){
             throw new AttestationException("Environment can not be parsed. " + envOverridesCopy.get(ENV_ENVIRONMENT));
-        }
-
-        // identityScope could be parsed
-        var identityScope = IdentityScope.fromString(envOverridesCopy.get(ENV_IDENTITY_SCOPE));
-        if(identityScope == null){
-            throw new AttestationException("IdentityScope can not be parsed. " + envOverridesCopy.get(ENV_IDENTITY_SCOPE));
         }
 
         // make sure there's no unexpected overrides

--- a/src/test/java/com/uid2/shared/secure/gcpoidc/PolicyValidatorTest.java
+++ b/src/test/java/com/uid2/shared/secure/gcpoidc/PolicyValidatorTest.java
@@ -42,18 +42,6 @@ public class PolicyValidatorTest {
     }
 
     @Test
-    public void testValicationFailure_UnknownScope() {
-        var validator = new PolicyValidator();
-        var payload = generateBasicPayload();
-        var envOverrides = new HashMap<>(payload.getEnvOverrides());
-        envOverrides.put(PolicyValidator.ENV_IDENTITY_SCOPE, "scope1");
-        var newPayload = payload.toBuilder()
-                .envOverrides(envOverrides)
-                .build();
-        assertThrows(AttestationException.class, ()-> validator.validate(newPayload));
-    }
-
-    @Test
     public void testValicationSuccess_IntegNoOptionalEnv() throws AttestationException {
         var validator = new PolicyValidator();
         var payload = generateBasicPayload();
@@ -173,7 +161,6 @@ public class PolicyValidatorTest {
                 .restartPolicy("NEVER")
                 .envOverrides(Map.of(
                         PolicyValidator.ENV_ENVIRONMENT, "prod",
-                        PolicyValidator.ENV_IDENTITY_SCOPE, "uid2",
                         PolicyValidator.ENV_OPERATOR_API_KEY, "dummy_api_key"
                 ));
         return builder.build();

--- a/src/test/resources/com.uid2.shared/test/secure/gcpoidc/jwt_payload_policy_valid.json
+++ b/src/test/resources/com.uid2.shared/test/secure/gcpoidc/jwt_payload_policy_valid.json
@@ -28,7 +28,6 @@
       "image_id": "sha256:5be33a19451733a45ea1bdb340fcb858a0fc733e91ca0a0d99638652f6dcabd0",
       "env_override": {
         "DEPLOYMENT_ENVIRONMENT": "prod",
-        "IDENTITY_SCOPE": "uid2",
         "API_TOKEN": "dummy"
       },
       "cmd_override": null,


### PR DESCRIPTION
1. Remove IdentityScope from required env in PolicyValidator.
2. Adjust some log level.
