### PR TITLE
differentiate 401 with 500

### DIFF
--- a/src/main/java/com/uid2/shared/secure/AttestationClientException.java
+++ b/src/main/java/com/uid2/shared/secure/AttestationClientException.java
@@ -1,0 +1,12 @@
+package com.uid2.shared.secure;
+
+public class AttestationClientException extends AttestationException
+{
+    public AttestationClientException(Throwable cause) {
+        super(cause, true);
+    }
+
+    public AttestationClientException(String message) {
+        super(message, true);
+    }
+}

--- a/src/main/java/com/uid2/shared/secure/AttestationException.java
+++ b/src/main/java/com/uid2/shared/secure/AttestationException.java
@@ -1,10 +1,27 @@
 package com.uid2.shared.secure;
 
 public class AttestationException extends Exception {
-    public AttestationException(Throwable cause) {
-        super(cause);
+    private final boolean isClientError;
+
+    public boolean IsClientError(){
+        return this.isClientError;
     }
+
+    public AttestationException(Throwable cause, boolean isClientError) {
+        super(cause);
+        this.isClientError = isClientError;
+    }
+
+    public AttestationException(Throwable cause) {
+        this(cause, false);
+    }
+
+    public AttestationException(String cause, boolean isClientError) {
+        super(cause);
+        this.isClientError = isClientError;
+    }
+
     public AttestationException(String message) {
-        super(message);
+        this(message, false);
     }
 }

--- a/src/main/java/com/uid2/shared/secure/AttestationException.java
+++ b/src/main/java/com/uid2/shared/secure/AttestationException.java
@@ -3,7 +3,7 @@ package com.uid2.shared.secure;
 public class AttestationException extends Exception {
     private final boolean isClientError;
 
-    public boolean IsClientError(){
+    public boolean IsClientError() {
         return this.isClientError;
     }
 

--- a/src/main/java/com/uid2/shared/secure/AttestationFailure.java
+++ b/src/main/java/com/uid2/shared/secure/AttestationFailure.java
@@ -6,6 +6,7 @@ public enum AttestationFailure {
     BAD_PAYLOAD,
     BAD_CERTIFICATE,
     FORBIDDEN_ENCLAVE,
+    OTHER,
     UNKNOWN;
 
     public String explain() {
@@ -20,6 +21,8 @@ public enum AttestationFailure {
                 return "Cannot verify the certificate chain";
             case FORBIDDEN_ENCLAVE:
                 return "The enclave identifier is unknown";
+            case OTHER:
+                return "Other reason, see related AttestationException for details";
             default:
                 return "Unknown reason";
         }

--- a/src/main/java/com/uid2/shared/secure/AttestationFailure.java
+++ b/src/main/java/com/uid2/shared/secure/AttestationFailure.java
@@ -6,7 +6,6 @@ public enum AttestationFailure {
     BAD_PAYLOAD,
     BAD_CERTIFICATE,
     FORBIDDEN_ENCLAVE,
-    OTHER,
     UNKNOWN;
 
     public String explain() {
@@ -21,8 +20,6 @@ public enum AttestationFailure {
                 return "Cannot verify the certificate chain";
             case FORBIDDEN_ENCLAVE:
                 return "The enclave identifier is unknown";
-            case OTHER:
-                return "Other reason, see related AttestationException for details";
             default:
                 return "Unknown reason";
         }

--- a/src/main/java/com/uid2/shared/secure/AttestationResult.java
+++ b/src/main/java/com/uid2/shared/secure/AttestationResult.java
@@ -36,7 +36,7 @@ public class AttestationResult {
     public AttestationFailure getFailure() { return this.failure; }
 
     public String getReason() {
-        if(this.attestationClientException != null){
+        if (this.attestationClientException != null) {
             return this.attestationClientException.getMessage();
         }
         return this.failure.explain();

--- a/src/main/java/com/uid2/shared/secure/AttestationResult.java
+++ b/src/main/java/com/uid2/shared/secure/AttestationResult.java
@@ -6,27 +6,27 @@ public class AttestationResult {
 
     private final String enclaveId;
 
-    private final AttestationClientException attestationException;
+    private final AttestationClientException attestationClientException;
 
     public AttestationResult(AttestationFailure reasonToFail) {
         this.failure = reasonToFail;
         this.publicKey = null;
         this.enclaveId = "Failed attestation, enclave Id unknown";
-        this.attestationException = null;
+        this.attestationClientException = null;
     }
 
     public AttestationResult(AttestationClientException exception) {
         this.failure = AttestationFailure.OTHER;
         this.publicKey = null;
         this.enclaveId = "Failed attestation, enclave Id unknown";
-        this.attestationException = exception;
+        this.attestationClientException = exception;
     }
 
     public AttestationResult(byte[] publicKey, String enclaveId) {
         this.failure = AttestationFailure.NONE;
         this.publicKey = publicKey;
         this.enclaveId = enclaveId;
-        this.attestationException = null;
+        this.attestationClientException = null;
     }
 
     public boolean isSuccess() {
@@ -36,8 +36,8 @@ public class AttestationResult {
     public AttestationFailure getFailure() { return this.failure; }
 
     public String getReason() {
-        if(this.attestationException != null){
-            return this.attestationException.getMessage();
+        if(this.attestationClientException != null){
+            return this.attestationClientException.getMessage();
         }
         return this.failure.explain();
     }

--- a/src/main/java/com/uid2/shared/secure/AttestationResult.java
+++ b/src/main/java/com/uid2/shared/secure/AttestationResult.java
@@ -16,7 +16,7 @@ public class AttestationResult {
     }
 
     public AttestationResult(AttestationClientException exception) {
-        this.failure = AttestationFailure.OTHER;
+        this.failure = AttestationFailure.UNKNOWN;
         this.publicKey = null;
         this.enclaveId = "Failed attestation, enclave Id unknown";
         this.attestationClientException = exception;

--- a/src/main/java/com/uid2/shared/secure/AttestationResult.java
+++ b/src/main/java/com/uid2/shared/secure/AttestationResult.java
@@ -6,16 +6,27 @@ public class AttestationResult {
 
     private final String enclaveId;
 
+    private final AttestationClientException attestationException;
+
     public AttestationResult(AttestationFailure reasonToFail) {
         this.failure = reasonToFail;
         this.publicKey = null;
         this.enclaveId = "Failed attestation, enclave Id unknown";
+        this.attestationException = null;
+    }
+
+    public AttestationResult(AttestationClientException exception) {
+        this.failure = AttestationFailure.OTHER;
+        this.publicKey = null;
+        this.enclaveId = "Failed attestation, enclave Id unknown";
+        this.attestationException = exception;
     }
 
     public AttestationResult(byte[] publicKey, String enclaveId) {
         this.failure = AttestationFailure.NONE;
         this.publicKey = publicKey;
         this.enclaveId = enclaveId;
+        this.attestationException = null;
     }
 
     public boolean isSuccess() {
@@ -25,6 +36,9 @@ public class AttestationResult {
     public AttestationFailure getFailure() { return this.failure; }
 
     public String getReason() {
+        if(this.attestationException != null){
+            return this.attestationException.getMessage();
+        }
         return this.failure.explain();
     }
 

--- a/src/main/java/com/uid2/shared/secure/AzureCCAttestationProvider.java
+++ b/src/main/java/com/uid2/shared/secure/AzureCCAttestationProvider.java
@@ -62,7 +62,6 @@ public class AzureCCAttestationProvider implements IAttestationProvider {
         catch (AttestationException ae) {
             handler.handle(Future.failedFuture(ae));
         } catch (Exception ex) {
-            // Server error
             handler.handle(Future.failedFuture(new AttestationException(ex)));
         }
     }

--- a/src/main/java/com/uid2/shared/secure/AzureCCAttestationProvider.java
+++ b/src/main/java/com/uid2/shared/secure/AzureCCAttestationProvider.java
@@ -52,11 +52,17 @@ public class AzureCCAttestationProvider implements IAttestationProvider {
                 log.info("Successfully attested azure-cc against registered enclaves, enclave id: " + enclaveId);
                 handler.handle(Future.succeededFuture(new AttestationResult(publicKey, enclaveId)));
             } else {
-                throw new AttestationException("Unregistered enclave, enclave id: " + enclaveId);
+                log.warn("Got unsupported azure-cc enclave id: " + enclaveId);
+                handler.handle(Future.succeededFuture(new AttestationResult(AttestationFailure.FORBIDDEN_ENCLAVE)));
             }
-        } catch (AttestationException ex) {
-            handler.handle(Future.failedFuture(ex));
+        }
+        catch (AttestationClientException ace){
+            handler.handle(Future.succeededFuture(new AttestationResult(ace)));
+        }
+        catch (AttestationException ae) {
+            handler.handle(Future.failedFuture(ae));
         } catch (Exception ex) {
+            // Server error
             handler.handle(Future.failedFuture(new AttestationException(ex)));
         }
     }

--- a/src/main/java/com/uid2/shared/secure/GcpOidcAttestationProvider.java
+++ b/src/main/java/com/uid2/shared/secure/GcpOidcAttestationProvider.java
@@ -41,6 +41,7 @@ public class GcpOidcAttestationProvider implements IAttestationProvider{
             if (enclaveId != null) {
                 handler.handle(Future.succeededFuture(new AttestationResult(publicKey, enclaveId)));
             } else {
+                LOGGER.warn("Can not find registered gcp-oidc enclave id.");
                 handler.handle(Future.succeededFuture(new AttestationResult(AttestationFailure.FORBIDDEN_ENCLAVE)));
             }
         }

--- a/src/main/java/com/uid2/shared/secure/GcpOidcAttestationProvider.java
+++ b/src/main/java/com/uid2/shared/secure/GcpOidcAttestationProvider.java
@@ -47,8 +47,8 @@ public class GcpOidcAttestationProvider implements IAttestationProvider{
         catch (AttestationClientException ace){
             handler.handle(Future.succeededFuture(new AttestationResult(ace)));
         }
-        catch (AttestationException ex){
-            handler.handle(Future.failedFuture(ex));
+        catch (AttestationException ae){
+            handler.handle(Future.failedFuture(ae));
         }
         catch (Exception ex) {
             handler.handle(Future.failedFuture(new AttestationException(ex)));

--- a/src/main/java/com/uid2/shared/secure/GcpOidcAttestationProvider.java
+++ b/src/main/java/com/uid2/shared/secure/GcpOidcAttestationProvider.java
@@ -92,8 +92,10 @@ public class GcpOidcAttestationProvider implements IAttestationProvider{
                 LOGGER.info("Validator version: " + policyValidator.getVersion() + ", result: " + enclaveId);
 
                 if (allowedEnclaveIds.contains(enclaveId)) {
-                    LOGGER.info("Successfully attested OIDC against registered enclaves");
+                    LOGGER.info("Successfully attested gcp-oidc against registered enclaves");
                     return enclaveId;
+                } else {
+                    LOGGER.warn("Got unsupported gcp-oidc enclave id: " + enclaveId);
                 }
             } catch (Exception ex) {
                 lastException = ex;

--- a/src/main/java/com/uid2/shared/secure/azurecc/MaaTokenSignatureValidator.java
+++ b/src/main/java/com/uid2/shared/secure/azurecc/MaaTokenSignatureValidator.java
@@ -5,6 +5,7 @@ import com.google.api.client.json.webtoken.JsonWebSignature;
 import com.google.api.client.util.Clock;
 import com.google.auth.oauth2.TokenVerifier;
 import com.google.common.base.Strings;
+import com.uid2.shared.secure.AttestationClientException;
 import com.uid2.shared.secure.AttestationException;
 
 import java.io.IOException;
@@ -65,7 +66,7 @@ public class MaaTokenSignatureValidator implements IMaaTokenSignatureValidator {
                 tokenVerifier.verify(tokenString);
             }
         } catch (TokenVerifier.VerificationException e) {
-            throw new AttestationException("Fail to validate the token signature, error: " + e.getMessage());
+            throw new AttestationClientException("Fail to validate the token signature, error: " + e.getMessage());
         } catch (IOException e) {
             throw new AttestationException("Fail to parse token, error: " + e.getMessage());
         }

--- a/src/main/java/com/uid2/shared/secure/azurecc/PolicyValidator.java
+++ b/src/main/java/com/uid2/shared/secure/azurecc/PolicyValidator.java
@@ -1,6 +1,7 @@
 package com.uid2.shared.secure.azurecc;
 
 import com.google.common.base.Strings;
+import com.uid2.shared.secure.AttestationClientException;
 import com.uid2.shared.secure.AttestationException;
 
 public class PolicyValidator implements IPolicyValidator{
@@ -16,11 +17,11 @@ public class PolicyValidator implements IPolicyValidator{
 
     private void verifyPublicKey(MaaTokenPayload maaTokenPayload, String publicKey) throws AttestationException {
         if(Strings.isNullOrEmpty(publicKey)){
-            throw new AttestationException("public key to check is null or empty");
+            throw new AttestationClientException("public key to check is null or empty");
         }
         var runtimePublicKey = maaTokenPayload.getRuntimeData().getPublicKey();
         if(!publicKey.equals(runtimePublicKey)){
-            throw new AttestationException(
+            throw new AttestationClientException(
                     String.format("Public key in payload is not match expected value. More info: runtime(%s), expected(%s)",
                             runtimePublicKey,
                             publicKey
@@ -30,25 +31,25 @@ public class PolicyValidator implements IPolicyValidator{
 
     private void verifyVM(MaaTokenPayload maaTokenPayload) throws AttestationException {
         if(!maaTokenPayload.isSevSnpVM()){
-            throw new AttestationException("Not in SevSnp VM");
+            throw new AttestationClientException("Not in SevSnp VM");
         }
         if(!maaTokenPayload.isUtilityVMCompliant()){
-            throw new AttestationException("Not run in Azure Compliance Utility VM");
+            throw new AttestationClientException("Not run in Azure Compliance Utility VM");
         }
         if(maaTokenPayload.isVmDebuggable()){
-            throw new AttestationException("The underlying harware should not run in debug mode");
+            throw new AttestationClientException("The underlying harware should not run in debug mode");
         }
     }
 
     private void verifyLocation(MaaTokenPayload maaTokenPayload) throws AttestationException {
         var location = maaTokenPayload.getRuntimeData().getLocation();
         if(Strings.isNullOrEmpty(location)){
-            throw new AttestationException("Location is not specified.");
+            throw new AttestationClientException("Location is not specified.");
         }
         var lowerCaseLocation = location.toLowerCase();
         if(lowerCaseLocation.contains(LOCATION_CHINA) ||
            lowerCaseLocation.contains(LOCATION_EU)){
-            throw new AttestationException("Location is not supported. Value: " + location);
+            throw new AttestationClientException("Location is not supported. Value: " + location);
         }
     }
 }

--- a/src/main/java/com/uid2/shared/secure/azurecc/PolicyValidator.java
+++ b/src/main/java/com/uid2/shared/secure/azurecc/PolicyValidator.java
@@ -37,7 +37,7 @@ public class PolicyValidator implements IPolicyValidator{
             throw new AttestationClientException("Not run in Azure Compliance Utility VM");
         }
         if(maaTokenPayload.isVmDebuggable()){
-            throw new AttestationClientException("The underlying harware should not run in debug mode");
+            throw new AttestationClientException("The underlying hardware should not run in debug mode");
         }
     }
 


### PR DESCRIPTION
The error handling logic is on core: https://github.com/IABTechLab/uid2-core/blob/c62c6400a50f121996dd00d85957d59940bebd00/src/main/java/com/uid2/core/vertx/CoreVerticle.java#L237
- If unhandled exception throws, or `AyncResult` failed, it will return 500
- If `AsyncResult` succeeds, but the `AttestationResult` failed, it will return 401 with reason.
- Otherwise, if `AttestationResult` succeeds, it will return 200.

It would be an overkill to define all error enum in `AttestationFailure`. Hence I added addtional `AttestationClientException` field in `AttestationResult`. If it's not null, we will get failure reason from its error message.

This change will impact new GCP attestation provider and new Azure attestation provider. Other attestation provider will not be impacted.