### PR TITLE
sch-UID2-2470 add roles to service links

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-shared</artifactId>
-    <version>5.19.0-0a359c5a31</version>
+    <version>5.19.9-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Library for all the shared uid2 operations</description>
     <url>https://github.com/IABTechLab/uid2docs</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-shared</artifactId>
-    <version>5.19.9-SNAPSHOT</version>
+    <version>5.19.10-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Library for all the shared uid2 operations</description>
     <url>https://github.com/IABTechLab/uid2docs</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-shared</artifactId>
-    <version>5.19.10-SNAPSHOT</version>
+    <version>5.19.0-0a359c5a31</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Library for all the shared uid2 operations</description>
     <url>https://github.com/IABTechLab/uid2docs</url>

--- a/src/main/java/com/uid2/shared/model/ServiceLink.java
+++ b/src/main/java/com/uid2/shared/model/ServiceLink.java
@@ -1,8 +1,17 @@
 package com.uid2.shared.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
+import com.uid2.shared.auth.Role;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
 
 public class ServiceLink {
     @JsonProperty("site_id")
@@ -12,12 +21,20 @@ public class ServiceLink {
     @JsonProperty("link_id")
     private String linkId;
     private String name;
+    private Set<Role> roles;
 
-    public ServiceLink(String linkId, int serviceId, int siteId, String name) {
+    @JsonCreator
+    public ServiceLink(
+            @JsonProperty("link_id") String linkId,
+            @JsonProperty("service_id") int serviceId,
+            @JsonProperty("site_id") int siteId,
+            @JsonProperty("name") String name,
+            @JsonProperty("roles") Set<Role> roles) {
         this.linkId = linkId;
         this.serviceId = serviceId;
         this.siteId = siteId;
         this.name = name;
+        this.roles = Objects.requireNonNullElseGet(roles, HashSet::new);
     }
 
     public String getLinkId() {
@@ -39,8 +56,17 @@ public class ServiceLink {
     public String getName() {
         return name;
     }
+
     public void setName(String name) {
         this.name = name;
+    }
+
+    public Set<Role> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(Set<Role> roles) {
+        this.roles = Objects.requireNonNullElseGet(roles, HashSet::new);
     }
 
     @Override
@@ -50,6 +76,7 @@ public class ServiceLink {
                 ", serviceId=" + serviceId +
                 ", linkId='" + linkId + '\'' +
                 ", name='" + name + '\'' +
+                ", roles=" + roles +
                 '}';
     }
 
@@ -58,11 +85,12 @@ public class ServiceLink {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ServiceLink serviceLink = (ServiceLink) o;
-        return siteId == serviceLink.siteId && serviceId == serviceLink.serviceId && linkId.equals(serviceLink.linkId) && name.equals(serviceLink.name);
+        return siteId == serviceLink.siteId && serviceId == serviceLink.serviceId && linkId.equals(serviceLink.linkId)
+                && name.equals(serviceLink.name) && roles.equals(serviceLink.roles);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(siteId, serviceId, linkId, name);
+        return Objects.hash(siteId, serviceId, linkId, name, roles.hashCode());
     }
 }

--- a/src/main/java/com/uid2/shared/model/ServiceLink.java
+++ b/src/main/java/com/uid2/shared/model/ServiceLink.java
@@ -1,5 +1,6 @@
 package com.uid2.shared.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
@@ -9,6 +10,7 @@ import com.uid2.shared.auth.Role;
 import java.util.HashSet;
 import java.util.Set;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ServiceLink {
     @JsonProperty("site_id")
     private final int siteId;

--- a/src/main/java/com/uid2/shared/model/ServiceLink.java
+++ b/src/main/java/com/uid2/shared/model/ServiceLink.java
@@ -2,15 +2,11 @@ package com.uid2.shared.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 import com.uid2.shared.auth.Role;
 
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 
 public class ServiceLink {

--- a/src/main/java/com/uid2/shared/store/parser/ServiceLinkParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/ServiceLinkParser.java
@@ -15,10 +15,6 @@ public class ServiceLinkParser implements Parser<Map<String, ServiceLink>> {
 
     private static final ObjectMapper OBJECT_MAPPER = Mapper.getInstance();
 
-    static {
-        OBJECT_MAPPER.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
-    }
-
     @Override
     public ParsingResult<Map<String, ServiceLink>> deserialize(InputStream inputStream) throws IOException {
         ServiceLink[] serviceLinks = OBJECT_MAPPER.readValue(inputStream, ServiceLink[].class);

--- a/src/main/java/com/uid2/shared/store/parser/ServiceLinkParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/ServiceLinkParser.java
@@ -15,6 +15,10 @@ public class ServiceLinkParser implements Parser<Map<String, ServiceLink>> {
 
     private static final ObjectMapper OBJECT_MAPPER = Mapper.getInstance();
 
+    static {
+        OBJECT_MAPPER.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
+    }
+
     @Override
     public ParsingResult<Map<String, ServiceLink>> deserialize(InputStream inputStream) throws IOException {
         ServiceLink[] serviceLinks = OBJECT_MAPPER.readValue(inputStream, ServiceLink[].class);

--- a/src/main/java/com/uid2/shared/store/parser/ServiceLinkParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/ServiceLinkParser.java
@@ -1,31 +1,32 @@
 package com.uid2.shared.store.parser;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import com.uid2.shared.Utils;
+import com.uid2.shared.auth.ClientKey;
 import com.uid2.shared.model.ServiceLink;
+import com.uid2.shared.util.Mapper;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class ServiceLinkParser implements Parser<Map<String, ServiceLink>> {
 
+    private static final ObjectMapper OBJECT_MAPPER = Mapper.getInstance();
+
+    static {
+        OBJECT_MAPPER.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
+    }
+
     @Override
     public ParsingResult<Map<String, ServiceLink>> deserialize(InputStream inputStream) throws IOException {
-        JsonArray spec = Utils.toJsonArray(inputStream);
-        final HashMap<String, ServiceLink> serviceLinkList = new HashMap<>();
-        for (int i = 0; i < spec.size(); i++) {
-            JsonObject serviceLinkSpec = spec.getJsonObject(i);
-            String linkId = serviceLinkSpec.getString("link_id");
-            int serviceId = serviceLinkSpec.getInteger("service_id");
-            int siteId = serviceLinkSpec.getInteger("site_id");
-            String name = serviceLinkSpec.getString("name");
-
-            ServiceLink serviceLink = new ServiceLink(linkId, serviceId, siteId, name);
-            String key = serviceId + "_" + linkId;
-            serviceLinkList.put(key, serviceLink);
-        }
+        ServiceLink[] serviceLinks = OBJECT_MAPPER.readValue(inputStream, ServiceLink[].class);
+        Map<String, ServiceLink> serviceLinkList = Arrays.stream(serviceLinks).collect(Collectors.toMap(s -> (s.getServiceId() + "_" + s.getLinkId()), s -> s));
         return new ParsingResult<>(serviceLinkList, serviceLinkList.size());
     }
 }

--- a/src/main/java/com/uid2/shared/store/parser/ServiceLinkParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/ServiceLinkParser.java
@@ -3,12 +3,8 @@ package com.uid2.shared.store.parser;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import com.uid2.shared.Utils;
-import com.uid2.shared.auth.ClientKey;
 import com.uid2.shared.model.ServiceLink;
 import com.uid2.shared.util.Mapper;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/test/java/com/uid2/shared/store/RotatingServiceLinkStoreTest.java
+++ b/src/test/java/com/uid2/shared/store/RotatingServiceLinkStoreTest.java
@@ -56,7 +56,7 @@ public class RotatingServiceLinkStoreTest {
     }
 
     @Test
-    public void loadContentEmptyArray() throws Exception {
+    public void loadContent_EmptyArray_LoadsZeroServiceLinks() throws Exception {
         JsonArray content = new JsonArray();
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
         final long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));
@@ -65,7 +65,7 @@ public class RotatingServiceLinkStoreTest {
     }
 
     @Test
-    public void loadContentMultipleServices() throws Exception {
+    public void loadContent_MultipleServiceLinksStored_LoadsAllServiceLinks() throws Exception {
         JsonArray content = new JsonArray();
         ServiceLink l1 = addServiceLink(content, "abc123", 1, 123, "Test Service 1", Set.of());
         ServiceLink l2 = addServiceLink(content, "abc123", 2, 123, "test1", Set.of(Role.MAPPER));
@@ -77,8 +77,9 @@ public class RotatingServiceLinkStoreTest {
         assertEquals(4, count);
         assertTrue(serviceLinkStore.getAllServiceLinks().containsAll(Arrays.asList(l1, l2, l3, l4)));
     }
+
     @Test
-    public void findServiceLinksMultipleServices() throws Exception {
+    public void getServiceLink_MultipleServiceLinksStored_FindsCorrectServiceLink() throws Exception {
         JsonArray content = new JsonArray();
         ServiceLink l1 = addServiceLink(content, "abc123", 1, 123, "Test Service 1", Set.of());
         ServiceLink l2 = addServiceLink(content, "abc123", 2, 123, "test1", Set.of(Role.MAPPER));
@@ -96,7 +97,7 @@ public class RotatingServiceLinkStoreTest {
     }
 
     @Test
-    public void createServiceEmptyRole() throws Exception {
+    public void createService_NullRole_CreatesServiceLinkWithEmptySetOfRoles() throws Exception {
         JsonArray content = new JsonArray();
         ServiceLink sl = addServiceLink(content, "jkl1011", 3, 124, "Test Service", null);
 

--- a/src/test/java/com/uid2/shared/store/RotatingServiceLinkStoreTest.java
+++ b/src/test/java/com/uid2/shared/store/RotatingServiceLinkStoreTest.java
@@ -1,5 +1,6 @@
 package com.uid2.shared.store;
 
+import com.uid2.shared.auth.Role;
 import com.uid2.shared.cloud.ICloudStorage;
 import com.uid2.shared.model.ServiceLink;
 import com.uid2.shared.store.reader.RotatingServiceLinkStore;
@@ -14,6 +15,7 @@ import org.mockito.MockitoAnnotations;
 
 
 import java.util.Arrays;
+import java.util.Set;
 
 import static com.uid2.shared.TestUtilites.makeInputStream;
 import static org.junit.jupiter.api.Assertions.*;
@@ -45,8 +47,8 @@ public class RotatingServiceLinkStoreTest {
         return metadata;
     }
 
-    private ServiceLink addServiceLink(JsonArray content, String linkId, int serviceId, int siteId, String name) {
-        ServiceLink link = new ServiceLink(linkId, serviceId, siteId, name);
+    private ServiceLink addServiceLink(JsonArray content, String linkId, int serviceId, int siteId, String name, Set<Role> roles) {
+        ServiceLink link = new ServiceLink(linkId, serviceId, siteId, name, roles);
         JsonObject jo = JsonObject.mapFrom(link);
         content.add(jo);
         return link;
@@ -64,10 +66,10 @@ public class RotatingServiceLinkStoreTest {
     @Test
     public void loadContentMultipleServices() throws Exception {
         JsonArray content = new JsonArray();
-        ServiceLink l1 = addServiceLink(content, "abc123", 1, 123, "Test Service 1");
-        ServiceLink l2 = addServiceLink(content, "abc123", 2, 123, "test1");
-        ServiceLink l3 = addServiceLink(content, "ghi789", 1, 123, "Test Service 1");
-        ServiceLink l4 = addServiceLink(content, "jkl1011", 3, 124, "test2");
+        ServiceLink l1 = addServiceLink(content, "abc123", 1, 123, "Test Service 1", Set.of());
+        ServiceLink l2 = addServiceLink(content, "abc123", 2, 123, "test1", Set.of(Role.MAPPER));
+        ServiceLink l3 = addServiceLink(content, "ghi789", 1, 123, "Test Service 1", Set.of(Role.MAPPER, Role.SHARER));
+        ServiceLink l4 = addServiceLink(content, "jkl1011", 3, 124, "test2", Set.of(Role.SHARER));
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
         final long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));
@@ -77,10 +79,10 @@ public class RotatingServiceLinkStoreTest {
     @Test
     public void findServiceLinksMultipleServices() throws Exception {
         JsonArray content = new JsonArray();
-        ServiceLink l1 = addServiceLink(content, "abc123", 1, 123, "Test Service 1");
-        ServiceLink l2 = addServiceLink(content, "abc123", 2, 123, "test1");
-        ServiceLink l3 = addServiceLink(content, "ghi789", 1, 123, "Test Service 1");
-        ServiceLink l4 = addServiceLink(content, "jkl1011", 3, 124, "test2");
+        ServiceLink l1 = addServiceLink(content, "abc123", 1, 123, "Test Service 1", Set.of());
+        ServiceLink l2 = addServiceLink(content, "abc123", 2, 123, "test1", Set.of(Role.MAPPER));
+        ServiceLink l3 = addServiceLink(content, "ghi789", 1, 123, "Test Service 1", Set.of(Role.MAPPER, Role.SHARER));
+        ServiceLink l4 = addServiceLink(content, "jkl1011", 3, 124, "test2", Set.of(Role.SHARER));
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
         final long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));

--- a/src/test/java/com/uid2/shared/store/RotatingServiceLinkStoreTest.java
+++ b/src/test/java/com/uid2/shared/store/RotatingServiceLinkStoreTest.java
@@ -83,43 +83,27 @@ public class RotatingServiceLinkStoreTest {
         ServiceLink l1 = addServiceLink(content, "abc123", 1, 123, "Test Service 1", Set.of());
         ServiceLink l2 = addServiceLink(content, "abc123", 2, 123, "test1", Set.of(Role.MAPPER));
         ServiceLink l3 = addServiceLink(content, "ghi789", 1, 123, "Test Service 1", Set.of(Role.MAPPER, Role.SHARER));
-        ServiceLink l4 = addServiceLink(content, "jkl1011", 3, 124, "test2", null);
+
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
         final long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));
 
-        ServiceLink sl1 = serviceLinkStore.getServiceLink(1, "abc123");
-        assertNotNull(sl1);
-        assertEquals("Test Service 1", sl1.getName());
-        assertEquals(1, sl1.getServiceId());
-        assertEquals(123, sl1.getSiteId());
-        assertEquals("abc123", sl1.getLinkId());
-        assertEquals(new HashSet<Role>(), sl1.getRoles());
-
-        ServiceLink sl2 = serviceLinkStore.getServiceLink(2, "abc123");
-        assertNotNull(sl2);
-        assertEquals("test1", sl2.getName());
-        assertEquals(2, sl2.getServiceId());
-        assertEquals(123, sl2.getSiteId());
-        assertEquals("abc123", sl2.getLinkId());
-        assertEquals(Set.of(Role.MAPPER), sl2.getRoles());
-
-        ServiceLink sl3 = serviceLinkStore.getServiceLink(1, "ghi789");
-        assertNotNull(sl3);
-        assertEquals("Test Service 1", sl3.getName());
-        assertEquals(1, sl3.getServiceId());
-        assertEquals(123, sl3.getSiteId());
-        assertEquals("ghi789", sl3.getLinkId());
-        assertEquals(Set.of(Role.MAPPER, Role.SHARER), sl3.getRoles());
-
-        ServiceLink sl4 = serviceLinkStore.getServiceLink(3, "jkl1011");
-        assertNotNull(sl4);
-        assertEquals("test2", sl4.getName());
-        assertEquals(3, sl4.getServiceId());
-        assertEquals(124, sl4.getSiteId());
-        assertEquals("jkl1011", sl4.getLinkId());
-        assertEquals(new HashSet<Role>(), sl4.getRoles());
+        assertEquals(Arrays.asList(serviceLinkStore.getServiceLink(1, "abc123"),
+                serviceLinkStore.getServiceLink(2, "abc123"),
+                serviceLinkStore.getServiceLink(1, "ghi789")), Arrays.asList(l1, l2, l3));
 
         assertNull(serviceLinkStore.getServiceLink(4, "missing"));
+    }
+
+    @Test
+    public void createServiceEmptyRole() throws Exception {
+        JsonArray content = new JsonArray();
+        ServiceLink sl = addServiceLink(content, "jkl1011", 3, 124, "Test Service", null);
+
+        when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
+
+        final long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));
+        assertEquals(1, count);
+        assertEquals(serviceLinkStore.getServiceLink(3, "jkl1011"), new ServiceLink("jkl1011", 3, 124, "Test Service", Set.of()));
     }
 }

--- a/src/test/java/com/uid2/shared/store/RotatingServiceLinkStoreTest.java
+++ b/src/test/java/com/uid2/shared/store/RotatingServiceLinkStoreTest.java
@@ -15,6 +15,7 @@ import org.mockito.MockitoAnnotations;
 
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 
 import static com.uid2.shared.TestUtilites.makeInputStream;
@@ -87,12 +88,37 @@ public class RotatingServiceLinkStoreTest {
 
         final long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));
 
-        ServiceLink sl = serviceLinkStore.getServiceLink(1, "abc123");
-        assertNotNull(sl);
-        assertEquals("Test Service 1", sl.getName());
-        assertEquals(1, sl.getServiceId());
-        assertEquals(123, sl.getSiteId());
-        assertEquals("abc123", sl.getLinkId());
+        ServiceLink sl1 = serviceLinkStore.getServiceLink(1, "abc123");
+        assertNotNull(sl1);
+        assertEquals("Test Service 1", sl1.getName());
+        assertEquals(1, sl1.getServiceId());
+        assertEquals(123, sl1.getSiteId());
+        assertEquals("abc123", sl1.getLinkId());
+        assertEquals(new HashSet<Role>(), sl1.getRoles());
+
+        ServiceLink sl2 = serviceLinkStore.getServiceLink(2, "abc123");
+        assertNotNull(sl2);
+        assertEquals("test1", sl2.getName());
+        assertEquals(2, sl2.getServiceId());
+        assertEquals(123, sl2.getSiteId());
+        assertEquals("abc123", sl2.getLinkId());
+        assertEquals(Set.of(Role.MAPPER), sl2.getRoles());
+
+        ServiceLink sl3 = serviceLinkStore.getServiceLink(1, "ghi789");
+        assertNotNull(sl3);
+        assertEquals("Test Service 1", sl3.getName());
+        assertEquals(1, sl3.getServiceId());
+        assertEquals(123, sl3.getSiteId());
+        assertEquals("ghi789", sl3.getLinkId());
+        assertEquals(Set.of(Role.MAPPER, Role.SHARER), sl3.getRoles());
+
+        ServiceLink sl4 = serviceLinkStore.getServiceLink(3, "jkl1011");
+        assertNotNull(sl4);
+        assertEquals("test2", sl4.getName());
+        assertEquals(3, sl4.getServiceId());
+        assertEquals(124, sl4.getSiteId());
+        assertEquals("jkl1011", sl4.getLinkId());
+        assertEquals(new HashSet<Role>(), sl4.getRoles());
 
         assertNull(serviceLinkStore.getServiceLink(4, "missing"));
     }

--- a/src/test/java/com/uid2/shared/store/RotatingServiceLinkStoreTest.java
+++ b/src/test/java/com/uid2/shared/store/RotatingServiceLinkStoreTest.java
@@ -69,7 +69,7 @@ public class RotatingServiceLinkStoreTest {
         ServiceLink l1 = addServiceLink(content, "abc123", 1, 123, "Test Service 1", Set.of());
         ServiceLink l2 = addServiceLink(content, "abc123", 2, 123, "test1", Set.of(Role.MAPPER));
         ServiceLink l3 = addServiceLink(content, "ghi789", 1, 123, "Test Service 1", Set.of(Role.MAPPER, Role.SHARER));
-        ServiceLink l4 = addServiceLink(content, "jkl1011", 3, 124, "test2", Set.of(Role.SHARER));
+        ServiceLink l4 = addServiceLink(content, "jkl1011", 3, 124, "test2", null);
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
         final long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));
@@ -82,7 +82,7 @@ public class RotatingServiceLinkStoreTest {
         ServiceLink l1 = addServiceLink(content, "abc123", 1, 123, "Test Service 1", Set.of());
         ServiceLink l2 = addServiceLink(content, "abc123", 2, 123, "test1", Set.of(Role.MAPPER));
         ServiceLink l3 = addServiceLink(content, "ghi789", 1, 123, "Test Service 1", Set.of(Role.MAPPER, Role.SHARER));
-        ServiceLink l4 = addServiceLink(content, "jkl1011", 3, 124, "test2", Set.of(Role.SHARER));
+        ServiceLink l4 = addServiceLink(content, "jkl1011", 3, 124, "test2", null);
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
         final long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));

--- a/src/test/java/com/uid2/shared/store/RotatingServiceLinkStoreTest.java
+++ b/src/test/java/com/uid2/shared/store/RotatingServiceLinkStoreTest.java
@@ -16,6 +16,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static com.uid2.shared.TestUtilites.makeInputStream;
@@ -56,7 +57,7 @@ public class RotatingServiceLinkStoreTest {
     }
 
     @Test
-    public void loadContent_EmptyArray_LoadsZeroServiceLinks() throws Exception {
+    public void loadContent_emptyArray_loadsZeroServiceLinks() throws Exception {
         JsonArray content = new JsonArray();
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
         final long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));
@@ -65,7 +66,7 @@ public class RotatingServiceLinkStoreTest {
     }
 
     @Test
-    public void loadContent_MultipleServiceLinksStored_LoadsAllServiceLinks() throws Exception {
+    public void loadContent_multipleServiceLinksStored_loadsAllServiceLinks() throws Exception {
         JsonArray content = new JsonArray();
         ServiceLink l1 = addServiceLink(content, "abc123", 1, 123, "Test Service 1", Set.of());
         ServiceLink l2 = addServiceLink(content, "abc123", 2, 123, "test1", Set.of(Role.MAPPER));
@@ -79,7 +80,7 @@ public class RotatingServiceLinkStoreTest {
     }
 
     @Test
-    public void getServiceLink_MultipleServiceLinksStored_FindsCorrectServiceLink() throws Exception {
+    public void getServiceLink_multipleServiceLinksStored_findsCorrectServiceLink() throws Exception {
         JsonArray content = new JsonArray();
         ServiceLink l1 = addServiceLink(content, "abc123", 1, 123, "Test Service 1", Set.of());
         ServiceLink l2 = addServiceLink(content, "abc123", 2, 123, "test1", Set.of(Role.MAPPER));
@@ -89,15 +90,18 @@ public class RotatingServiceLinkStoreTest {
 
         final long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));
 
-        assertEquals(Arrays.asList(serviceLinkStore.getServiceLink(1, "abc123"),
+        List<ServiceLink> expected = List.of(l1, l2, l3);
+        List<ServiceLink> actual = List.of(
+                serviceLinkStore.getServiceLink(1, "abc123"),
                 serviceLinkStore.getServiceLink(2, "abc123"),
-                serviceLinkStore.getServiceLink(1, "ghi789")), Arrays.asList(l1, l2, l3));
+                serviceLinkStore.getServiceLink(1, "ghi789"));
 
+        assertEquals(expected, actual);
         assertNull(serviceLinkStore.getServiceLink(4, "missing"));
     }
 
     @Test
-    public void createService_NullRole_CreatesServiceLinkWithEmptySetOfRoles() throws Exception {
+    public void createService_nullRole_createsServiceLinkWithEmptySetOfRoles() throws Exception {
         JsonArray content = new JsonArray();
         ServiceLink sl = addServiceLink(content, "jkl1011", 3, 124, "Test Service", null);
 


### PR DESCRIPTION
Allow Service Links to support roles by adding role parameter to Service Link model. Changed model and parser to use object mapper pattern. If role is null, then an empty hashset is created. Tested creation of service links with empty role, single role, multiple roles and null value. 