### PR TITLE
Fixed issue where null JWT sent to Core on startup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-shared</artifactId>
-    <version>6.0.14-SNAPSHOT</version>
+    <version>6.0.18-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Library for all the shared uid2 operations</description>
     <url>https://github.com/IABTechLab/uid2docs</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-shared</artifactId>
-    <version>6.0.10-208e0b52b2</version>
+    <version>6.0.14-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Library for all the shared uid2 operations</description>
     <url>https://github.com/IABTechLab/uid2docs</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-shared</artifactId>
-    <version>6.0.18-SNAPSHOT</version>
+    <version>6.0.20-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Library for all the shared uid2 operations</description>
     <url>https://github.com/IABTechLab/uid2docs</url>

--- a/src/main/java/com/uid2/shared/attest/UidCoreClient.java
+++ b/src/main/java/com/uid2/shared/attest/UidCoreClient.java
@@ -132,6 +132,8 @@ public class UidCoreClient implements IUidCoreClient, DownloadCloudStorage {
         String jwtToken = this.getJWT();
         if (jwtToken != null && !jwtToken.isBlank()) {
             headers.put(Const.Attestation.AttestationJWTHeader, jwtToken);
+        } else {
+            LOGGER.warn("getJWT returned an empty or null string for the JWT");
         }
 
         HttpResponse<String> httpResponse;

--- a/src/main/java/com/uid2/shared/attest/UidCoreClient.java
+++ b/src/main/java/com/uid2/shared/attest/UidCoreClient.java
@@ -66,28 +66,21 @@ public class UidCoreClient implements IUidCoreClient, DownloadCloudStorage {
 
     @Override
     public InputStream download(String path) throws CloudStorageException {
-        String coreJWT = this.getJWT();
-        return this.internalDownload(path, coreJWT);
-    }
-
-    @Deprecated
-    public InputStream downloadFromOptOut(String path) throws CloudStorageException {
-        String optOutJWT = attestationTokenRetriever.getOptOutJWT();
-        return this.internalDownload(path, optOutJWT);
+        return this.internalDownload(path);
     }
 
     protected String getJWT() {
         return this.getAttestationTokenRetriever().getCoreJWT();
     }
 
-    private InputStream internalDownload(String path, String jwtToken) throws CloudStorageException {
+    private InputStream internalDownload(String path) throws CloudStorageException {
         try {
             InputStream inputStream;
             if (allowContentFromLocalFileSystem && path.startsWith("file:/tmp/uid2")) {
                 // returns `file:/tmp/uid2` urlConnection directly
                 inputStream = readContentFromLocalFileSystem(path, this.proxy);
             } else {
-                inputStream = getWithAttest(path, jwtToken);
+                inputStream = getWithAttest(path);
             }
             return inputStream;
         } catch (Exception e) {
@@ -100,31 +93,28 @@ public class UidCoreClient implements IUidCoreClient, DownloadCloudStorage {
         return (proxy == null ? new URL(path).openConnection() : new URL(path).openConnection(proxy)).getInputStream();
     }
 
-    private InputStream getWithAttest(String path, String jwtToken) throws IOException, InterruptedException, AttestationTokenRetrieverException {
+    private InputStream getWithAttest(String path) throws IOException, AttestationTokenRetrieverException {
         if (!attestationTokenRetriever.attested()) {
             attestationTokenRetriever.attest();
-            if (jwtToken == null || jwtToken.isEmpty()) {
-                jwtToken = this.getJWT();
-            }
         }
 
         String attestationToken = attestationTokenRetriever.getAttestationToken();
 
         HttpResponse<String> httpResponse;
-        httpResponse = sendHttpRequest(path, attestationToken, jwtToken);
+        httpResponse = sendHttpRequest(path, attestationToken);
 
         // This should never happen, but keeping this part of the code just to be extra safe.
         if (httpResponse.statusCode() == 401) {
             LOGGER.info("Initial response from UID2 Core returned 401, performing attestation");
             attestationTokenRetriever.attest();
             attestationToken = attestationTokenRetriever.getAttestationToken();
-            httpResponse = sendHttpRequest(path, attestationToken, jwtToken);
+            httpResponse = sendHttpRequest(path, attestationToken);
         }
 
         return Utils.convertHttpResponseToInputStream(httpResponse);
     }
 
-    private HttpResponse<String> sendHttpRequest(String path, String attestationToken, String attestationJWT) throws IOException {
+    private HttpResponse<String> sendHttpRequest(String path, String attestationToken) throws IOException {
         URI uri = URI.create(path);
         if (this.enforceHttps && !"https".equalsIgnoreCase(uri.getScheme())) {
             throw new IOException("UidCoreClient requires HTTPS connection");
@@ -138,8 +128,10 @@ public class UidCoreClient implements IUidCoreClient, DownloadCloudStorage {
         if (attestationToken != null && !attestationToken.isBlank()) {
             headers.put(Const.Attestation.AttestationTokenHeader, attestationToken);
         }
-        if (attestationJWT != null && !attestationJWT.isBlank()) {
-            headers.put(Const.Attestation.AttestationJWTHeader, attestationJWT);
+
+        String jwtToken = this.getJWT();
+        if (jwtToken != null && !jwtToken.isBlank()) {
+            headers.put(Const.Attestation.AttestationJWTHeader, jwtToken);
         }
 
         HttpResponse<String> httpResponse;

--- a/src/main/java/com/uid2/shared/attest/UidCoreClient.java
+++ b/src/main/java/com/uid2/shared/attest/UidCoreClient.java
@@ -10,8 +10,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.*;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.HashMap;
 
@@ -108,6 +106,9 @@ public class UidCoreClient implements IUidCoreClient, DownloadCloudStorage {
         }
 
         String attestationToken = attestationTokenRetriever.getAttestationToken();
+        if (jwtToken == null || jwtToken.isEmpty()) {
+            jwtToken = this.getJWT();
+        }
 
         HttpResponse<String> httpResponse;
         httpResponse = sendHttpRequest(path, attestationToken, jwtToken);
@@ -123,7 +124,7 @@ public class UidCoreClient implements IUidCoreClient, DownloadCloudStorage {
         return Utils.convertHttpResponseToInputStream(httpResponse);
     }
 
-    private HttpResponse<String> sendHttpRequest(String path, String attestationToken, String attestationJWT) throws IOException, InterruptedException {
+    private HttpResponse<String> sendHttpRequest(String path, String attestationToken, String attestationJWT) throws IOException {
         URI uri = URI.create(path);
         if (this.enforceHttps && !"https".equalsIgnoreCase(uri.getScheme())) {
             throw new IOException("UidCoreClient requires HTTPS connection");

--- a/src/main/java/com/uid2/shared/attest/UidCoreClient.java
+++ b/src/main/java/com/uid2/shared/attest/UidCoreClient.java
@@ -103,12 +103,12 @@ public class UidCoreClient implements IUidCoreClient, DownloadCloudStorage {
     private InputStream getWithAttest(String path, String jwtToken) throws IOException, InterruptedException, AttestationTokenRetrieverException {
         if (!attestationTokenRetriever.attested()) {
             attestationTokenRetriever.attest();
+            if (jwtToken == null || jwtToken.isEmpty()) {
+                jwtToken = this.getJWT();
+            }
         }
 
         String attestationToken = attestationTokenRetriever.getAttestationToken();
-        if (jwtToken == null || jwtToken.isEmpty()) {
-            jwtToken = this.getJWT();
-        }
 
         HttpResponse<String> httpResponse;
         httpResponse = sendHttpRequest(path, attestationToken, jwtToken);

--- a/src/test/java/com/uid2/shared/attest/UidCoreClientTest.java
+++ b/src/test/java/com/uid2/shared/attest/UidCoreClientTest.java
@@ -14,6 +14,7 @@ import java.net.Proxy;
 import java.net.http.HttpResponse;
 import java.util.HashMap;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.*;
 
 public class UidCoreClientTest {
@@ -60,7 +61,7 @@ public class UidCoreClientTest {
     }
 
     @Test
-    public void Download_With_Attest_Uses_JWT_Second_Call() throws IOException, CloudStorageException, AttestationTokenRetrieverException {
+    public void DownloadWithAttest_UsesJWTSecondCall() throws IOException, CloudStorageException, AttestationTokenRetrieverException {
         HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
 
         // this test checks that if the getCoreJWT returns null, then the UidCoreClient will call getCoreJWT after attestation to get the
@@ -82,10 +83,11 @@ public class UidCoreClientTest {
         when(mockHttpClient.get("https://download", expectedHeaders)).thenReturn(mockHttpResponse);
 
         uidCoreClient.download("https://download");
-        verify(mockAttestationTokenRetriever, times(1)).attest();
-        verify(mockAttestationTokenRetriever, times(2)).getCoreJWT();
-
-        verify(mockHttpClient, times(1)).get("https://download", expectedHeaders);
+        assertAll(
+                () -> verify(mockAttestationTokenRetriever, times(1)).attest(),
+                () -> verify(mockAttestationTokenRetriever, times(2)).getCoreJWT(),
+                () -> verify(mockHttpClient, times(1)).get("https://download", expectedHeaders)
+        );
     }
 
     @Test

--- a/src/test/java/com/uid2/shared/attest/UidCoreClientTest.java
+++ b/src/test/java/com/uid2/shared/attest/UidCoreClientTest.java
@@ -61,36 +61,6 @@ public class UidCoreClientTest {
     }
 
     @Test
-    public void DownloadWithAttest_UsesJWTSecondCall() throws IOException, CloudStorageException, AttestationTokenRetrieverException {
-        HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
-
-        // this test checks that if the getCoreJWT returns null, then the UidCoreClient will call getCoreJWT after attestation to get the
-        // expected value
-        when(mockAttestationTokenRetriever.getAttestationToken()).thenReturn("testAttestationToken");
-        when(mockAttestationTokenRetriever.getCoreJWT()).thenReturn(null,"testCoreJWT");
-        when(mockAttestationTokenRetriever.getOptOutJWT()).thenReturn("testOptOutJWT");
-        uidCoreClient.setUserToken("testUserToken");
-
-        String expectedResponseBody = "Hello, world!";
-        when(mockHttpResponse.body()).thenReturn(expectedResponseBody);
-
-        HashMap<String, String> expectedHeaders = new HashMap<>();
-        expectedHeaders.put(Const.Http.AppVersionHeader, "testAppVersionHeader");
-        expectedHeaders.put("Authorization", "Bearer testUserToken");
-        expectedHeaders.put("Attestation-Token", "testAttestationToken");
-        expectedHeaders.put("Attestation-JWT", "testCoreJWT");
-
-        when(mockHttpClient.get("https://download", expectedHeaders)).thenReturn(mockHttpResponse);
-
-        uidCoreClient.download("https://download");
-        assertAll(
-                () -> verify(mockAttestationTokenRetriever, times(1)).attest(),
-                () -> verify(mockAttestationTokenRetriever, times(2)).getCoreJWT(),
-                () -> verify(mockHttpClient, times(1)).get("https://download", expectedHeaders)
-        );
-    }
-
-    @Test
     public void Download_EnforceHttpWhenPathNoHttps_ExceptionThrown() {
         when(mockAttestationTokenRetriever.getAttestationToken()).thenReturn("testAttestationToken");
 

--- a/src/test/java/com/uid2/shared/secure/AttestationTokenTest.java
+++ b/src/test/java/com/uid2/shared/secure/AttestationTokenTest.java
@@ -82,8 +82,8 @@ public class AttestationTokenTest {
         final long defaultLifetime = 7200;
 
         // using the default constructor requires the use of a range, rather than a specific value
-        final Instant expiryLowerBound = Instant.now().plusSeconds(defaultLifetime + (5 * 60) + 1); // bounds are exclusive
-        final Instant expiryUpperBound = Instant.now().plusSeconds(defaultLifetime + (10 * 60) - 1);
+        final Instant expiryLowerBound = Instant.now().plusSeconds(defaultLifetime + (5 * 60)); // lower bound is inclusive
+        final Instant expiryUpperBound = Instant.now().plusSeconds(defaultLifetime + (10 * 60) - 1); // upper bound is exclusive
         final AttestationTokenService ats = new AttestationTokenService(ENCRYPTION_KEY, SALT); // until the default constructor is removed, this must use it for the test to be valid
 
         final String attestationToken = ats.createToken("userToken").getEncodedAttestationToken();


### PR DESCRIPTION
Added unit test
Tested in unit tests locally
Tested in E2E tests locally
Tested in a branch deploy of both Operator and Optout