### PR TITLE
Attest Core URL as passed in by the operators

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-shared</artifactId>
-    <version>6.1.8-SNAPSHOT</version>
+    <version>6.1.9-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Library for all the shared uid2 operations</description>
     <url>https://github.com/IABTechLab/uid2docs</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-shared</artifactId>
-    <version>6.1.11-SNAPSHOT</version>
+    <version>6.1.17-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Library for all the shared uid2 operations</description>
     <url>https://github.com/IABTechLab/uid2docs</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-shared</artifactId>
-    <version>6.1.17-SNAPSHOT</version>
+    <version>6.1.19-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Library for all the shared uid2 operations</description>
     <url>https://github.com/IABTechLab/uid2docs</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-shared</artifactId>
-    <version>6.1.9-SNAPSHOT</version>
+    <version>6.1.10-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Library for all the shared uid2 operations</description>
     <url>https://github.com/IABTechLab/uid2docs</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-shared</artifactId>
-    <version>6.1.10-SNAPSHOT</version>
+    <version>6.1.11-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Library for all the shared uid2 operations</description>
     <url>https://github.com/IABTechLab/uid2docs</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-shared</artifactId>
-    <version>6.1.9-SNAPSHOT</version>
+    <version>6.1.8-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Library for all the shared uid2 operations</description>
     <url>https://github.com/IABTechLab/uid2docs</url>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-shared</artifactId>
-    <version>6.1.4-6aa70802e2</version>
+    <version>6.1.9-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Library for all the shared uid2 operations</description>
     <url>https://github.com/IABTechLab/uid2docs</url>
@@ -33,6 +33,14 @@
         <url>https://github.com/IABTechLab/uid2-shared</url>
     </scm>
 
+    <repositories>
+        <repository>
+            <id>snapshots-repo</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <releases><enabled>false</enabled></releases>
+            <snapshots><enabled>true</enabled></snapshots>
+        </repository>
+    </repositories>
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
@@ -71,7 +79,7 @@
         <dependency>
             <groupId>com.uid2</groupId>
             <artifactId>uid2-attestation-api</artifactId>
-            <version>1.5.0-676519b018</version>
+            <version>1.6.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>io.vertx</groupId>

--- a/src/main/java/com/uid2/shared/attest/AttestationTokenRetriever.java
+++ b/src/main/java/com/uid2/shared/attest/AttestationTokenRetriever.java
@@ -152,7 +152,7 @@ public class AttestationTokenRetriever {
         try {
             KeyPair keyPair = generateKeyPair();
             byte[] publicKey = keyPair.getPublic().getEncoded();
-            byte[] userData = this.attestationEndpoint.getBytes(StandardCharsets.UTF_8);
+            byte[] userData = StandardCharsets.UTF_16.encode(this.attestationEndpoint).array();
             JsonObject requestJson = JsonObject.of(
                     "attestation_request", Base64.getEncoder().encodeToString(attestationProvider.getAttestationRequest(publicKey, userData)),
                     "public_key", Base64.getEncoder().encodeToString(publicKey),

--- a/src/main/java/com/uid2/shared/attest/AttestationTokenRetriever.java
+++ b/src/main/java/com/uid2/shared/attest/AttestationTokenRetriever.java
@@ -35,6 +35,7 @@ public class AttestationTokenRetriever {
     private final AtomicReference<String> coreJwt;
     private final Handler<Pair<Integer, String>> responseWatcher;
     private final String attestationEndpoint;
+    private final byte[] encodedAttestationEndpoint;
     private final IClock clock;
     private final Vertx vertx;
     private final URLConnectionHttpClient httpClient;
@@ -69,6 +70,7 @@ public class AttestationTokenRetriever {
                                      int attestCheckMilliseconds) {
         this.vertx = vertx;
         this.attestationEndpoint = attestationEndpoint;
+        this.encodedAttestationEndpoint = this.encodeStringUnicodeAttestationEndpoint(attestationEndpoint);
         this.clientApiToken = clientApiToken;
         this.appVersion = appVersion;
         this.attestationProvider = attestationProvider;
@@ -151,7 +153,7 @@ public class AttestationTokenRetriever {
             KeyPair keyPair = generateKeyPair();
             byte[] publicKey = keyPair.getPublic().getEncoded();
             JsonObject requestJson = JsonObject.of(
-                    "attestation_request", Base64.getEncoder().encodeToString(attestationProvider.getAttestationRequest(publicKey, this.encodeAttestationEndpoint())),
+                    "attestation_request", Base64.getEncoder().encodeToString(attestationProvider.getAttestationRequest(publicKey, this.encodedAttestationEndpoint)),
                     "public_key", Base64.getEncoder().encodeToString(publicKey),
                     "application_name", appVersion.getAppName(),
                     "application_version", appVersion.getAppVersion()
@@ -288,9 +290,9 @@ public class AttestationTokenRetriever {
         return this.attestationToken.get() != null && this.clock.now().isBefore(this.attestationTokenExpiresAt);
     }
 
-    private byte[] encodeAttestationEndpoint() {
+    private byte[] encodeStringUnicodeAttestationEndpoint(String data) {
         // buffer.array() may include extra empty bytes at the end. This returns only the bytes that have data
-        ByteBuffer buffer = StandardCharsets.UTF_8.encode(this.attestationEndpoint);
+        ByteBuffer buffer = StandardCharsets.UTF_8.encode(data);
         return Arrays.copyOf(buffer.array(), buffer.limit());
     }
 }

--- a/src/main/java/com/uid2/shared/attest/AttestationTokenRetriever.java
+++ b/src/main/java/com/uid2/shared/attest/AttestationTokenRetriever.java
@@ -152,8 +152,9 @@ public class AttestationTokenRetriever {
         try {
             KeyPair keyPair = generateKeyPair();
             byte[] publicKey = keyPair.getPublic().getEncoded();
+            byte[] userData = this.attestationEndpoint.getBytes(StandardCharsets.UTF_8);
             JsonObject requestJson = JsonObject.of(
-                    "attestation_request", Base64.getEncoder().encodeToString(attestationProvider.getAttestationRequest(publicKey)),
+                    "attestation_request", Base64.getEncoder().encodeToString(attestationProvider.getAttestationRequest(publicKey, userData)),
                     "public_key", Base64.getEncoder().encodeToString(publicKey),
                     "application_name", appVersion.getAppName(),
                     "application_version", appVersion.getAppVersion()

--- a/src/main/java/com/uid2/shared/attest/NoAttestationProvider.java
+++ b/src/main/java/com/uid2/shared/attest/NoAttestationProvider.java
@@ -4,7 +4,7 @@ import com.uid2.enclave.IAttestationProvider;
 
 public class NoAttestationProvider implements IAttestationProvider {
     @Override
-    public byte[] getAttestationRequest(byte[] publicKey) {
+    public byte[] getAttestationRequest(byte[] publicKey, byte[] userData) {
         byte[] req = {0};
         return req;
     }

--- a/src/main/java/com/uid2/shared/attest/UidCoreClient.java
+++ b/src/main/java/com/uid2/shared/attest/UidCoreClient.java
@@ -20,31 +20,27 @@ public class UidCoreClient implements IUidCoreClient, DownloadCloudStorage {
     private final URLConnectionHttpClient httpClient;
     private String userToken;
     private final String appVersionHeader;
-    private final boolean enforceHttps;
     private boolean allowContentFromLocalFileSystem = false;
     private final AttestationTokenRetriever attestationTokenRetriever;
 
 
-    public static UidCoreClient createNoAttest(String userToken, boolean enforceHttps, AttestationTokenRetriever attestationTokenRetriever) {
-        return new UidCoreClient(userToken, CloudUtils.defaultProxy, enforceHttps, attestationTokenRetriever, null);
+    public static UidCoreClient createNoAttest(String userToken, AttestationTokenRetriever attestationTokenRetriever) {
+        return new UidCoreClient(userToken, CloudUtils.defaultProxy, attestationTokenRetriever, null);
     }
 
     public UidCoreClient(String userToken,
                          Proxy proxy,
-                         boolean enforceHttps,
                          AttestationTokenRetriever attestationTokenRetriever) {
-        this(userToken, proxy, enforceHttps, attestationTokenRetriever, null);
+        this(userToken, proxy, attestationTokenRetriever, null);
     }
 
     public UidCoreClient(String userToken,
                          Proxy proxy,
-                         boolean enforceHttps,
                          AttestationTokenRetriever attestationTokenRetriever,
                          URLConnectionHttpClient httpClient) {
         this.proxy = proxy;
         this.userToken = userToken;
         this.contentStorage = new PreSignedURLStorage(proxy);
-        this.enforceHttps = enforceHttps;
         if (httpClient == null) {
             this.httpClient = new URLConnectionHttpClient(proxy);
         } else {
@@ -116,9 +112,6 @@ public class UidCoreClient implements IUidCoreClient, DownloadCloudStorage {
 
     private HttpResponse<String> sendHttpRequest(String path, String attestationToken) throws IOException {
         URI uri = URI.create(path);
-        if (this.enforceHttps && !"https".equalsIgnoreCase(uri.getScheme())) {
-            throw new IOException("UidCoreClient requires HTTPS connection");
-        }
 
         HashMap<String, String> headers = new HashMap<>();
         headers.put(Const.Http.AppVersionHeader, this.appVersionHeader);

--- a/src/main/java/com/uid2/shared/attest/UidOptOutClient.java
+++ b/src/main/java/com/uid2/shared/attest/UidOptOutClient.java
@@ -8,21 +8,19 @@ import java.net.http.HttpClient;
 
 public class UidOptOutClient extends UidCoreClient {
     public static UidOptOutClient createNoAttest(String userToken, boolean enforceHttps, AttestationTokenRetriever attestationTokenRetriever) {
-        return new UidOptOutClient(userToken, CloudUtils.defaultProxy, enforceHttps, attestationTokenRetriever, null);
+        return new UidOptOutClient(userToken, CloudUtils.defaultProxy, attestationTokenRetriever, null);
     }
 
     public UidOptOutClient(String userToken,
                          Proxy proxy,
-                         boolean enforceHttps,
                          AttestationTokenRetriever attestationTokenRetriever) {
-        super(userToken, proxy, enforceHttps, attestationTokenRetriever, null);
+        super(userToken, proxy, attestationTokenRetriever, null);
     }
     public UidOptOutClient(String userToken,
                            Proxy proxy,
-                           boolean enforceHttps,
                            AttestationTokenRetriever attestationTokenRetriever,
                            URLConnectionHttpClient httpClient) {
-        super(userToken, proxy, enforceHttps, attestationTokenRetriever, httpClient);
+        super(userToken, proxy, attestationTokenRetriever, httpClient);
     }
 
     @Override

--- a/src/main/java/com/uid2/shared/secure/AttestationFailure.java
+++ b/src/main/java/com/uid2/shared/secure/AttestationFailure.java
@@ -6,6 +6,7 @@ public enum AttestationFailure {
     BAD_PAYLOAD,
     BAD_CERTIFICATE,
     FORBIDDEN_ENCLAVE,
+    UNKNOWN_ATTESTATION_URL,
     UNKNOWN;
 
     public String explain() {
@@ -20,6 +21,8 @@ public enum AttestationFailure {
                 return "Cannot verify the certificate chain";
             case FORBIDDEN_ENCLAVE:
                 return "The enclave identifier is unknown";
+            case UNKNOWN_ATTESTATION_URL:
+                return "The given attestation URL is unknown";
             default:
                 return "Unknown reason";
         }

--- a/src/main/java/com/uid2/shared/secure/AzureCCCoreAttestationService.java
+++ b/src/main/java/com/uid2/shared/secure/AzureCCCoreAttestationService.java
@@ -17,7 +17,7 @@ import java.util.Set;
 
 // CC stands for Confidential Container
 @Slf4j
-public class AzureCCAttestationProvider implements IAttestationProvider {
+public class AzureCCCoreAttestationService implements ICoreAttestationService {
 
     private final Set<String> allowedEnclaveIds = new HashSet<>();
 
@@ -25,12 +25,12 @@ public class AzureCCAttestationProvider implements IAttestationProvider {
 
     private final IPolicyValidator policyValidator;
 
-    public AzureCCAttestationProvider(String maaServerBaseUrl) {
+    public AzureCCCoreAttestationService(String maaServerBaseUrl) {
         this(new MaaTokenSignatureValidator(maaServerBaseUrl), new PolicyValidator());
     }
 
     // used in UT
-    protected AzureCCAttestationProvider(IMaaTokenSignatureValidator tokenSignatureValidator, IPolicyValidator policyValidator) {
+    protected AzureCCCoreAttestationService(IMaaTokenSignatureValidator tokenSignatureValidator, IPolicyValidator policyValidator) {
         this.tokenSignatureValidator = tokenSignatureValidator;
         this.policyValidator = policyValidator;
     }

--- a/src/main/java/com/uid2/shared/secure/GcpOidcCoreAttestationService.java
+++ b/src/main/java/com/uid2/shared/secure/GcpOidcCoreAttestationService.java
@@ -10,8 +10,8 @@ import org.slf4j.LoggerFactory;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
-public class GcpOidcAttestationProvider implements IAttestationProvider{
-    private static final Logger LOGGER = LoggerFactory.getLogger(GcpOidcAttestationProvider.class);
+public class GcpOidcCoreAttestationService implements ICoreAttestationService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GcpOidcCoreAttestationService.class);
 
     private final ITokenSignatureValidator tokenSignatureValidator;
 
@@ -19,12 +19,12 @@ public class GcpOidcAttestationProvider implements IAttestationProvider{
 
     private final Set<String> allowedEnclaveIds = new HashSet<>();
 
-    public GcpOidcAttestationProvider(){
+    public GcpOidcCoreAttestationService(){
         this(new TokenSignatureValidator(), Arrays.asList(new PolicyValidator()));
     }
 
     // used in UT
-    protected GcpOidcAttestationProvider(ITokenSignatureValidator tokenSignatureValidator, List<IPolicyValidator> supportedPolicyValidators){
+    protected GcpOidcCoreAttestationService(ITokenSignatureValidator tokenSignatureValidator, List<IPolicyValidator> supportedPolicyValidators){
         this.tokenSignatureValidator = tokenSignatureValidator;
         this.supportedPolicyValidators = supportedPolicyValidators;
     }

--- a/src/main/java/com/uid2/shared/secure/GcpVmidCoreAttestationService.java
+++ b/src/main/java/com/uid2/shared/secure/GcpVmidCoreAttestationService.java
@@ -17,14 +17,14 @@ import org.slf4j.LoggerFactory;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
-public class GcpVmidAttestationProvider implements IAttestationProvider {
-    private static final Logger LOGGER = LoggerFactory.getLogger(GcpVmidAttestationProvider.class);
+public class GcpVmidCoreAttestationService implements ICoreAttestationService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GcpVmidCoreAttestationService.class);
 
     private final InstanceDocumentVerifier idVerifier = new InstanceDocumentVerifier();
     private final VmConfigVerifier vmConfigVerifier;
     private final Set<String> allowedVmConfigIds = new HashSet<>();
 
-    public GcpVmidAttestationProvider(GoogleCredentials credentials, Set<String> enclaveParams) throws Exception {
+    public GcpVmidCoreAttestationService(GoogleCredentials credentials, Set<String> enclaveParams) throws Exception {
         LoadBalancerRegistry.getDefaultRegistry().register(new PickFirstLoadBalancerProvider());
         this.vmConfigVerifier = new VmConfigVerifier(credentials, enclaveParams);
         LOGGER.info("Using Google Service Account: " + credentials.toString());

--- a/src/main/java/com/uid2/shared/secure/ICoreAttestationService.java
+++ b/src/main/java/com/uid2/shared/secure/ICoreAttestationService.java
@@ -1,14 +1,11 @@
 package com.uid2.shared.secure;
 
-import com.uid2.shared.secure.AttestationException;
-import com.uid2.shared.secure.AttestationResult;
-
 import java.util.Collection;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 
-public interface IAttestationProvider {
+public interface ICoreAttestationService {
     void attest(
         byte[] attestationRequest,
         byte[] publicKey,

--- a/src/main/java/com/uid2/shared/secure/NitroCoreAttestationService.java
+++ b/src/main/java/com/uid2/shared/secure/NitroCoreAttestationService.java
@@ -3,8 +3,6 @@ package com.uid2.shared.secure;
 import com.uid2.shared.secure.nitro.AttestationDocument;
 import com.uid2.shared.secure.nitro.AttestationRequest;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
@@ -19,15 +17,15 @@ import io.vertx.core.Handler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class NitroAttestationProvider implements IAttestationProvider {
+public class NitroCoreAttestationService implements ICoreAttestationService {
 
     private final String attestationUrl;
     private Set<NitroEnclaveIdentifier> allowedEnclaveIds;
     private final ICertificateProvider certificateProvider;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(NitroAttestationProvider.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(NitroCoreAttestationService.class);
 
-    public NitroAttestationProvider(ICertificateProvider certificateProvider, String attestationUrl) {
+    public NitroCoreAttestationService(ICertificateProvider certificateProvider, String attestationUrl) {
         this.attestationUrl = attestationUrl;
         this.allowedEnclaveIds = new HashSet<>();
         this.certificateProvider = certificateProvider;

--- a/src/main/java/com/uid2/shared/secure/TrustedCoreAttestationService.java
+++ b/src/main/java/com/uid2/shared/secure/TrustedCoreAttestationService.java
@@ -7,8 +7,8 @@ import io.vertx.core.Handler;
 import java.util.Collection;
 import java.util.Collections;
 
-public class TrustedAttestationProvider implements IAttestationProvider {
-    public TrustedAttestationProvider() {}
+public class TrustedCoreAttestationService implements ICoreAttestationService {
+    public TrustedCoreAttestationService() {}
 
     @Override
     public void attest(byte[] attestationRequest, byte[] publicKey, Handler<AsyncResult<AttestationResult>> handler) {

--- a/src/main/java/com/uid2/shared/secure/gcpoidc/Environment.java
+++ b/src/main/java/com/uid2/shared/secure/gcpoidc/Environment.java
@@ -10,8 +10,7 @@ import java.util.stream.Stream;
 
 public enum Environment {
     Production("prod"),
-    Integration("integ"),
-    EndToEnd("endtoend");
+    Integration("integ");
 
     @Getter
     private String name;

--- a/src/main/java/com/uid2/shared/secure/gcpoidc/Environment.java
+++ b/src/main/java/com/uid2/shared/secure/gcpoidc/Environment.java
@@ -10,7 +10,8 @@ import java.util.stream.Stream;
 
 public enum Environment {
     Production("prod"),
-    Integration("integ");
+    Integration("integ"),
+    EndToEnd("endtoend");
 
     @Getter
     private String name;

--- a/src/main/java/com/uid2/shared/secure/gcpoidc/PolicyValidator.java
+++ b/src/main/java/com/uid2/shared/secure/gcpoidc/PolicyValidator.java
@@ -30,11 +30,13 @@ public class PolicyValidator implements IPolicyValidator {
 
     private static final List<String> REQUIRED_ENV_OVERRIDES = ImmutableList.of(
             ENV_ENVIRONMENT,
-            ENV_OPERATOR_API_KEY_SECRET_NAME
+            ENV_OPERATOR_API_KEY_SECRET_NAME,
+            ENV_CORE_ENDPOINT,
+            ENV_OPT_OUT_ENDPOINT
     );
 
     private static final Map<Environment, List<String>> OPTIONAL_ENV_OVERRIDES_MAP = ImmutableMap.of(
-            Environment.Integration, ImmutableList.of(ENV_CORE_ENDPOINT, ENV_OPT_OUT_ENDPOINT)
+            Environment.Integration, ImmutableList.of()
     );
 
     @Override

--- a/src/main/java/com/uid2/shared/secure/gcpoidc/PolicyValidator.java
+++ b/src/main/java/com/uid2/shared/secure/gcpoidc/PolicyValidator.java
@@ -27,8 +27,6 @@ public class PolicyValidator implements IPolicyValidator {
     public static final String ENV_OPT_OUT_ENDPOINT = "OPTOUT_BASE_URL";
     public static final String ENV_ENFORCE_HTTPS = "ENFORCE_HTTPS";
 
-    public static final String ENV_ENFORCE_HTTPS = "ENFORCE_HTTPS";
-
     public static final String EU_REGION_PREFIX = "europe";
 
     private static final List<String> REQUIRED_ENV_OVERRIDES = ImmutableList.of(

--- a/src/main/java/com/uid2/shared/secure/gcpoidc/PolicyValidator.java
+++ b/src/main/java/com/uid2/shared/secure/gcpoidc/PolicyValidator.java
@@ -34,8 +34,7 @@ public class PolicyValidator implements IPolicyValidator {
     );
 
     private static final Map<Environment, List<String>> OPTIONAL_ENV_OVERRIDES_MAP = ImmutableMap.of(
-            Environment.Integration, ImmutableList.of(ENV_CORE_ENDPOINT, ENV_OPT_OUT_ENDPOINT),
-            Environment.EndToEnd, ImmutableList.of(ENV_CORE_ENDPOINT, ENV_OPT_OUT_ENDPOINT, ENV_ENFORCE_HTTPS)
+            Environment.Integration, ImmutableList.of(ENV_CORE_ENDPOINT, ENV_OPT_OUT_ENDPOINT)
     );
 
     @Override

--- a/src/main/java/com/uid2/shared/secure/gcpoidc/PolicyValidator.java
+++ b/src/main/java/com/uid2/shared/secure/gcpoidc/PolicyValidator.java
@@ -27,6 +27,8 @@ public class PolicyValidator implements IPolicyValidator {
     public static final String ENV_OPT_OUT_ENDPOINT = "OPTOUT_BASE_URL";
     public static final String ENV_ENFORCE_HTTPS = "ENFORCE_HTTPS";
 
+    public static final String ENV_ENFORCE_HTTPS = "ENFORCE_HTTPS";
+
     public static final String EU_REGION_PREFIX = "europe";
 
     private static final List<String> REQUIRED_ENV_OVERRIDES = ImmutableList.of(
@@ -35,7 +37,8 @@ public class PolicyValidator implements IPolicyValidator {
     );
 
     private static final Map<Environment, List<String>> OPTIONAL_ENV_OVERRIDES_MAP = ImmutableMap.of(
-            Environment.Integration, ImmutableList.of(ENV_CORE_ENDPOINT, ENV_OPT_OUT_ENDPOINT, ENV_ENFORCE_HTTPS)
+            Environment.Integration, ImmutableList.of(ENV_CORE_ENDPOINT, ENV_OPT_OUT_ENDPOINT),
+            Environment.EndToEnd, ImmutableList.of(ENV_CORE_ENDPOINT, ENV_OPT_OUT_ENDPOINT, ENV_ENFORCE_HTTPS)
     );
 
     @Override

--- a/src/main/java/com/uid2/shared/secure/nitro/AttestationDocument.java
+++ b/src/main/java/com/uid2/shared/secure/nitro/AttestationDocument.java
@@ -6,6 +6,7 @@ import co.nstant.in.cbor.model.*;
 
 import java.io.ByteArrayInputStream;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.cert.CertPath;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
@@ -46,6 +47,7 @@ public class AttestationDocument {
     private List<byte[]> cabundle;
     private byte[] publicKey;
     private byte[] userData;
+    private String userDataString;
     private byte[] nonce;
 
     private AttestationDocument() {}
@@ -96,6 +98,7 @@ public class AttestationDocument {
             this.userData = null;
         } else {
             this.userData = ((ByteString) d).getBytes();
+            this.userDataString = new String(this.userData, StandardCharsets.UTF_16);
         }
     }
 
@@ -144,6 +147,10 @@ public class AttestationDocument {
 
     public byte[] getUserData() {
         return userData;
+    }
+
+    public String getUserDataString() {
+        return userDataString;
     }
 
     public byte[] getNonce() {

--- a/src/main/java/com/uid2/shared/secure/nitro/AttestationDocument.java
+++ b/src/main/java/com/uid2/shared/secure/nitro/AttestationDocument.java
@@ -98,7 +98,7 @@ public class AttestationDocument {
             this.userData = null;
         } else {
             this.userData = ((ByteString) d).getBytes();
-            this.userDataString = new String(this.userData, StandardCharsets.UTF_16);
+            this.userDataString = new String(this.userData, StandardCharsets.UTF_8);
         }
     }
 

--- a/src/main/java/com/uid2/shared/util/UrlEquivalenceValidator.java
+++ b/src/main/java/com/uid2/shared/util/UrlEquivalenceValidator.java
@@ -11,6 +11,7 @@ public class UrlEquivalenceValidator {
     }
 
     public static Boolean areUrlsEquivalent(String url1, String url2, Logger logger) {
+        logger.debug("Checking URLs equivalent: URL1: '{}', URL2: '{}'", url1, url2);
         URL first;
         try {
             first = new URL(url1);

--- a/src/main/java/com/uid2/shared/util/UrlEquivalenceValidator.java
+++ b/src/main/java/com/uid2/shared/util/UrlEquivalenceValidator.java
@@ -1,0 +1,31 @@
+package com.uid2.shared.util;
+
+import org.slf4j.Logger;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class UrlEquivalenceValidator {
+    private UrlEquivalenceValidator() {
+
+    }
+
+    public static Boolean areUrlsEquivalent(String url1, String url2, Logger logger) {
+        URL first;
+        try {
+            first = new URL(url1);
+        } catch (MalformedURLException e) {
+            logger.error("URL could not be parsed to a valid URL. Given URL: " + url1, e);
+            return false;
+        }
+        URL second;
+        try {
+            second = new URL(url2);
+        } catch (MalformedURLException e) {
+            logger.error("URL could not be parsed to a valid URL. Given URL: " + url2, e);
+            return false;
+        }
+
+        return first.getProtocol().equals(second.getProtocol()) && first.getHost().equalsIgnoreCase(second.getHost()) && first.getPort() == second.getPort();
+    }
+}

--- a/src/test/java/com/uid2/shared/attest/AttestationTokenRetrieverTest.java
+++ b/src/test/java/com/uid2/shared/attest/AttestationTokenRetrieverTest.java
@@ -1,5 +1,6 @@
 package com.uid2.shared.attest;
 
+import com.amazonaws.util.Base64;
 import com.uid2.enclave.AttestationException;
 import com.uid2.enclave.IAttestationProvider;
 import com.uid2.shared.ApplicationVersion;
@@ -15,16 +16,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.utils.Pair;
 
 import java.io.IOException;
 import java.net.Proxy;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -34,6 +36,7 @@ import static org.mockito.Mockito.*;
 @ExtendWith(VertxExtension.class)
 public class AttestationTokenRetrieverTest {
     private static final String ATTESTATION_ENDPOINT = "https://core-test.uidapi.com/attest";
+    private byte[] USER_DATA;
     private static final ApplicationVersion APP_VERSION = new ApplicationVersion("appName", "appVersion", new HashMap<String, String>()
     {{
         put("Component1", "Value1");
@@ -51,6 +54,8 @@ public class AttestationTokenRetrieverTest {
 
     @BeforeEach
     void setUp() {
+        ByteBuffer buffer = StandardCharsets.UTF_8.encode(ATTESTATION_ENDPOINT);
+        USER_DATA = Arrays.copyOf(buffer.array(), buffer.limit());
         when(clock.now()).thenReturn(Clock.systemUTC().instant().plusSeconds(100));
     }
 
@@ -59,7 +64,7 @@ public class AttestationTokenRetrieverTest {
         attestationTokenRetriever = getAttestationTokenRetriever(vertx);
 
         when(attestationProvider.isReady()).thenReturn(true);
-        when(attestationProvider.getAttestationRequest(any(), any())).thenReturn(new byte[1]);
+        when(attestationProvider.getAttestationRequest(any(), eq(USER_DATA))).thenReturn(new byte[1]);
 
         HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
         String expectedResponseBody = "{\"body\": {\"attestation_token\": \"test\",\"expiresAt\": \"2023-08-03T09:09:30.608597Z\",\"attestation_jwt_optout\": \"\",\"attestation_jwt_core\": \"\"},\"status\": \"success\"}";
@@ -243,8 +248,7 @@ public class AttestationTokenRetrieverTest {
         when(attestationProvider.isReady()).thenReturn(true);
         when(attestationProvider.getAttestationRequest(any(), any())).thenReturn(new byte[1]);
 
-        HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
-        String expectedResponseBody = "{\"body\": {\"attestation_token\": \"test\",\"expiresAt\": \"2023-08-03T09:09:30.608597Z\",\"attestation_jwt_optout\": \"test_jwt\",\"attestation_jwt_core\": \"\"},\"status\": \"success\"}";
+        HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);        String expectedResponseBody = "{\"body\": {\"attestation_token\": \"test\",\"expiresAt\": \"2023-08-03T09:09:30.608597Z\",\"attestation_jwt_optout\": \"test_jwt\",\"attestation_jwt_core\": \"\"},\"status\": \"success\"}";
         when(mockHttpResponse.body()).thenReturn(expectedResponseBody);
         when(mockHttpResponse.statusCode()).thenReturn(200);
 
@@ -295,6 +299,38 @@ public class AttestationTokenRetrieverTest {
         Assertions.assertNull(attestationTokenRetriever.getOptOutJWT());
         Assertions.assertNull(attestationTokenRetriever.getCoreJWT());
         verify(this.responseWatcher, times(1)).handle(Pair.of(200, expectedResponseBody));
+        testContext.completeNow();
+    }
+
+    @Test
+    public void attest_succeed_jsonRequest_includes_attestUrl(Vertx vertx, VertxTestContext testContext) throws  Exception{
+        attestationTokenRetriever = getAttestationTokenRetriever(vertx);
+
+        when(attestationProvider.isReady()).thenReturn(true);
+        when(attestationProvider.getAttestationRequest(any(), eq(USER_DATA))).thenReturn(USER_DATA);
+
+        HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
+        String expectedResponseBody = "{\"body\": {\"attestation_token\": \"test\",\"expiresAt\": \"2023-08-03T09:09:30.608597Z\",\"attestation_jwt_optout\": \"\",\"attestation_jwt_core\": \"\"},\"status\": \"success\"}";
+        when(mockHttpResponse.body()).thenReturn(expectedResponseBody);
+        when(mockHttpResponse.statusCode()).thenReturn(200);
+
+        ArgumentCaptor<String> bodyCapture = ArgumentCaptor.forClass(String.class);
+
+        when(mockHttpClient.post(eq(ATTESTATION_ENDPOINT), bodyCapture.capture(), any(HashMap.class))).thenReturn(mockHttpResponse);
+        when(mockAttestationTokenDecryptor.decrypt(any(), any())).thenReturn("test_attestation_token".getBytes(StandardCharsets.UTF_8));
+
+        when(clock.now()).thenReturn(Instant.parse("2023-08-01T00:00:00.111Z"));
+
+        attestationTokenRetriever.attest();
+
+        String body = bodyCapture.getValue();
+        JsonObject jsonBody = new JsonObject(body);
+        Assertions.assertNotNull(jsonBody.getString("attestation_request"));
+        String base64Content = jsonBody.getString("attestation_request");
+        byte[] data = Base64.decode(base64Content);
+        String decodedUrl = new String(data, StandardCharsets.UTF_8);
+        Assertions.assertEquals(ATTESTATION_ENDPOINT, decodedUrl);
+
         testContext.completeNow();
     }
 

--- a/src/test/java/com/uid2/shared/attest/AttestationTokenRetrieverTest.java
+++ b/src/test/java/com/uid2/shared/attest/AttestationTokenRetrieverTest.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.*;
 @ExtendWith(VertxExtension.class)
 public class AttestationTokenRetrieverTest {
     private static final String ATTESTATION_ENDPOINT = "https://core-test.uidapi.com/attest";
-    private byte[] USER_DATA;
+    private byte[] ENCODED_ATTESTATION_ENDPOINT;
     private static final ApplicationVersion APP_VERSION = new ApplicationVersion("appName", "appVersion", new HashMap<String, String>()
     {{
         put("Component1", "Value1");
@@ -55,7 +55,7 @@ public class AttestationTokenRetrieverTest {
     @BeforeEach
     void setUp() {
         ByteBuffer buffer = StandardCharsets.UTF_8.encode(ATTESTATION_ENDPOINT);
-        USER_DATA = Arrays.copyOf(buffer.array(), buffer.limit());
+        ENCODED_ATTESTATION_ENDPOINT = Arrays.copyOf(buffer.array(), buffer.limit());
         when(clock.now()).thenReturn(Clock.systemUTC().instant().plusSeconds(100));
     }
 
@@ -307,7 +307,7 @@ public class AttestationTokenRetrieverTest {
         attestationTokenRetriever = getAttestationTokenRetriever(vertx);
 
         when(attestationProvider.isReady()).thenReturn(true);
-        when(attestationProvider.getAttestationRequest(any(), eq(USER_DATA))).thenReturn(USER_DATA);
+        when(attestationProvider.getAttestationRequest(any(), eq(ENCODED_ATTESTATION_ENDPOINT))).thenReturn(ENCODED_ATTESTATION_ENDPOINT);
 
         HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
         String expectedResponseBody = "{\"body\": {\"attestation_token\": \"test\",\"expiresAt\": \"2023-08-03T09:09:30.608597Z\",\"attestation_jwt_optout\": \"\",\"attestation_jwt_core\": \"\"},\"status\": \"success\"}";
@@ -330,6 +330,8 @@ public class AttestationTokenRetrieverTest {
         byte[] data = Base64.decode(base64Content);
         String decodedUrl = new String(data, StandardCharsets.UTF_8);
         Assertions.assertEquals(ATTESTATION_ENDPOINT, decodedUrl);
+
+        verify(attestationProvider, times(1)).getAttestationRequest(any(), eq(ENCODED_ATTESTATION_ENDPOINT));
 
         testContext.completeNow();
     }

--- a/src/test/java/com/uid2/shared/attest/AttestationTokenRetrieverTest.java
+++ b/src/test/java/com/uid2/shared/attest/AttestationTokenRetrieverTest.java
@@ -64,7 +64,7 @@ public class AttestationTokenRetrieverTest {
         attestationTokenRetriever = getAttestationTokenRetriever(vertx);
 
         when(attestationProvider.isReady()).thenReturn(true);
-        when(attestationProvider.getAttestationRequest(any(), eq(USER_DATA))).thenReturn(new byte[1]);
+        when(attestationProvider.getAttestationRequest(any(), any())).thenReturn(new byte[1]);
 
         HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
         String expectedResponseBody = "{\"body\": {\"attestation_token\": \"test\",\"expiresAt\": \"2023-08-03T09:09:30.608597Z\",\"attestation_jwt_optout\": \"\",\"attestation_jwt_core\": \"\"},\"status\": \"success\"}";
@@ -303,7 +303,7 @@ public class AttestationTokenRetrieverTest {
     }
 
     @Test
-    public void attest_succeed_jsonRequest_includes_attestUrl(Vertx vertx, VertxTestContext testContext) throws  Exception{
+    public void attest_succeed_jsonRequest_includes_attestUrl_in_attestation_request(Vertx vertx, VertxTestContext testContext) throws  Exception{
         attestationTokenRetriever = getAttestationTokenRetriever(vertx);
 
         when(attestationProvider.isReady()).thenReturn(true);

--- a/src/test/java/com/uid2/shared/attest/AttestationTokenRetrieverTest.java
+++ b/src/test/java/com/uid2/shared/attest/AttestationTokenRetrieverTest.java
@@ -59,7 +59,7 @@ public class AttestationTokenRetrieverTest {
         attestationTokenRetriever = getAttestationTokenRetriever(vertx);
 
         when(attestationProvider.isReady()).thenReturn(true);
-        when(attestationProvider.getAttestationRequest(any())).thenReturn(new byte[1]);
+        when(attestationProvider.getAttestationRequest(any(), any())).thenReturn(new byte[1]);
 
         HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
         String expectedResponseBody = "{\"body\": {\"attestation_token\": \"test\",\"expiresAt\": \"2023-08-03T09:09:30.608597Z\",\"attestation_jwt_optout\": \"\",\"attestation_jwt_core\": \"\"},\"status\": \"success\"}";
@@ -83,7 +83,7 @@ public class AttestationTokenRetrieverTest {
         attestationTokenRetriever = getAttestationTokenRetriever(vertx);
 
         when(attestationProvider.isReady()).thenReturn(true);
-        when(attestationProvider.getAttestationRequest(any())).thenReturn(new byte[1]);
+        when(attestationProvider.getAttestationRequest(any(), any())).thenReturn(new byte[1]);
 
         HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
         String expectedResponseBody = "{\"body\": {\"attestation_token\": \"test\",\"expiresAt\": \"2023-08-01T00:00:00.111Z\",\"attestation_jwt_optout\": \"\",\"attestation_jwt_core\": \"\"},\"status\": \"success\"}";
@@ -111,7 +111,7 @@ public class AttestationTokenRetrieverTest {
         attestationTokenRetriever = getAttestationTokenRetriever(vertx);
 
         when(attestationProvider.isReady()).thenReturn(true);
-        when(attestationProvider.getAttestationRequest(any())).thenReturn(new byte[1]);
+        when(attestationProvider.getAttestationRequest(any(), any())).thenReturn(new byte[1]);
 
         HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
         String expectedResponseBody = "{\"body\": {\"attestation_token\": \"test\",\"expiresAt\": \"2023-08-01T00:00:00.111Z\",\"attestation_jwt_optout\": \"\",\"attestation_jwt_core\": \"\"},\"status\": \"success\"}";
@@ -139,7 +139,7 @@ public class AttestationTokenRetrieverTest {
         // The first is by attest() with true returned so that expiration check will be scheduled.
         // The second is by attestationExpirationCheck() with false, so that current check will be skipped.
         when(attestationProvider.isReady()).thenReturn(true, false);
-        when(attestationProvider.getAttestationRequest(any())).thenReturn(new byte[1]);
+        when(attestationProvider.getAttestationRequest(any(), any())).thenReturn(new byte[1]);
 
         HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
         String expectedResponseBody = "{\"body\": {\"attestation_token\": \"test\",\"expiresAt\": \"2023-08-01T00:00:00.111Z\",\"attestation_jwt_optout\": \"\",\"attestation_jwt_core\": \"\"},\"status\": \"success\"}";
@@ -165,7 +165,7 @@ public class AttestationTokenRetrieverTest {
         attestationTokenRetriever = getAttestationTokenRetriever(vertx);
 
         when(attestationProvider.isReady()).thenReturn(true);
-        when(attestationProvider.getAttestationRequest(any())).thenReturn(new byte[1]);
+        when(attestationProvider.getAttestationRequest(any(), any())).thenReturn(new byte[1]);
 
         JsonObject content = new JsonObject();
         JsonObject body = new JsonObject();
@@ -195,7 +195,7 @@ public class AttestationTokenRetrieverTest {
         attestationTokenRetriever = getAttestationTokenRetriever(vertx);
 
         when(attestationProvider.isReady()).thenReturn(true);
-        when(attestationProvider.getAttestationRequest(any())).thenReturn(new byte[1]);
+        when(attestationProvider.getAttestationRequest(any(), any())).thenReturn(new byte[1]);
 
         JsonObject content = new JsonObject();
         JsonObject body = new JsonObject();
@@ -226,7 +226,7 @@ public class AttestationTokenRetrieverTest {
         attestationTokenRetriever = getAttestationTokenRetriever(vertx);
 
         when(attestationProvider.isReady()).thenReturn(false);
-        when(attestationProvider.getAttestationRequest(any())).thenReturn(new byte[1]);
+        when(attestationProvider.getAttestationRequest(any(), any())).thenReturn(new byte[1]);
 
         AttestationTokenRetrieverException result = Assertions.assertThrows(AttestationTokenRetrieverException.class, () -> {
             attestationTokenRetriever.attest();
@@ -241,7 +241,7 @@ public class AttestationTokenRetrieverTest {
         attestationTokenRetriever = getAttestationTokenRetriever(vertx);
 
         when(attestationProvider.isReady()).thenReturn(true);
-        when(attestationProvider.getAttestationRequest(any())).thenReturn(new byte[1]);
+        when(attestationProvider.getAttestationRequest(any(), any())).thenReturn(new byte[1]);
 
         HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
         String expectedResponseBody = "{\"body\": {\"attestation_token\": \"test\",\"expiresAt\": \"2023-08-03T09:09:30.608597Z\",\"attestation_jwt_optout\": \"test_jwt\",\"attestation_jwt_core\": \"\"},\"status\": \"success\"}";
@@ -261,7 +261,7 @@ public class AttestationTokenRetrieverTest {
         attestationTokenRetriever = getAttestationTokenRetriever(vertx);
 
         when(attestationProvider.isReady()).thenReturn(true);
-        when(attestationProvider.getAttestationRequest(any())).thenReturn(new byte[1]);
+        when(attestationProvider.getAttestationRequest(any(), any())).thenReturn(new byte[1]);
 
         HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
         String expectedResponseBody = "{\"body\": {\"attestation_token\": \"test\",\"expiresAt\": \"2023-08-03T09:09:30.608597Z\",\"attestation_jwt_optout\": \"\",\"attestation_jwt_core\": \"test_jwt_core\"},\"status\": \"success\"}";
@@ -281,7 +281,7 @@ public class AttestationTokenRetrieverTest {
         attestationTokenRetriever = getAttestationTokenRetriever(vertx);
 
         when(attestationProvider.isReady()).thenReturn(true);
-        when(attestationProvider.getAttestationRequest(any())).thenReturn(new byte[1]);
+        when(attestationProvider.getAttestationRequest(any(), any())).thenReturn(new byte[1]);
 
         HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
         String expectedResponseBody = "{\"body\": {\"attestation_token\": \"test\",\"expiresAt\": \"2023-08-03T09:09:30.608597Z\"},\"status\": \"success\"}";

--- a/src/test/java/com/uid2/shared/attest/UidCoreClientTest.java
+++ b/src/test/java/com/uid2/shared/attest/UidCoreClientTest.java
@@ -33,7 +33,7 @@ public class UidCoreClientTest {
         when(mockAttestationTokenRetriever.getAppVersionHeader()).thenReturn("testAppVersionHeader");
         uidCoreClient = new UidCoreClient(
                 "userToken", proxy,
-                true, mockAttestationTokenRetriever, mockHttpClient);
+                mockAttestationTokenRetriever, mockHttpClient);
     }
 
     @Test
@@ -58,17 +58,6 @@ public class UidCoreClientTest {
         uidCoreClient.download("https://download");
         verify(mockAttestationTokenRetriever, times(1)).attest();
         verify(mockHttpClient, times(1)).get("https://download", expectedHeaders);
-    }
-
-    @Test
-    public void Download_EnforceHttpWhenPathNoHttps_ExceptionThrown() {
-        when(mockAttestationTokenRetriever.getAttestationToken()).thenReturn("testAttestationToken");
-
-        CloudStorageException result = Assert.assertThrows(CloudStorageException.class, () -> {
-            uidCoreClient.download("http://download");
-        });
-        String expectedExceptionMessage = "download http://download error: UidCoreClient requires HTTPS connection";
-        Assert.assertEquals(expectedExceptionMessage, result.getMessage());
     }
 
     @Test

--- a/src/test/java/com/uid2/shared/attest/UidOptOutClientTest.java
+++ b/src/test/java/com/uid2/shared/attest/UidOptOutClientTest.java
@@ -25,7 +25,7 @@ public class UidOptOutClientTest {
 
         optOutClient = new UidOptOutClient(
                 "userToken", proxy,
-                true, mockAttestationTokenRetriever, mockHttpClient);
+                mockAttestationTokenRetriever, mockHttpClient);
     }
 
     @Test

--- a/src/test/java/com/uid2/shared/secure/gcpoidc/PolicyValidatorTest.java
+++ b/src/test/java/com/uid2/shared/secure/gcpoidc/PolicyValidatorTest.java
@@ -11,14 +11,14 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class PolicyValidatorTest {
     @Test
-    public void testValicationSuccess_FullProd() throws AttestationException {
+    public void testValidationSuccess_FullProd() throws AttestationException {
         var validator = new PolicyValidator();
         var payload = generateBasicPayload();
         var enclaveId = validator.validate(payload);
     }
 
     @Test
-    public void testValicationFailure_MissRequiredEnvProd() {
+    public void testValidationFailure_MissRequiredEnvProd() {
         var validator = new PolicyValidator();
         var payload = generateBasicPayload();
         var envOverrides = new HashMap<>(payload.getEnvOverrides());
@@ -30,7 +30,7 @@ public class PolicyValidatorTest {
     }
 
     @Test
-    public void testValicationFailure_UnknownEnv() {
+    public void testValidationFailure_UnknownEnv() {
         var validator = new PolicyValidator();
         var payload = generateBasicPayload();
         var envOverrides = new HashMap<>(payload.getEnvOverrides());
@@ -42,24 +42,11 @@ public class PolicyValidatorTest {
     }
 
     @Test
-    public void testValicationSuccess_IntegNoOptionalEnv() throws AttestationException {
+    public void testValidationSuccess_IntegNoOptionalEnv() throws AttestationException {
         var validator = new PolicyValidator();
         var payload = generateBasicPayload();
         var envOverrides = new HashMap<>(payload.getEnvOverrides());
         envOverrides.put(PolicyValidator.ENV_ENVIRONMENT, "integ");
-        payload = payload.toBuilder()
-                .envOverrides(envOverrides)
-                .build();
-        var enclaveId = validator.validate(payload);
-    }
-
-    @Test
-    public void testValicationSuccess_IntegHasOptionalEnv() throws AttestationException {
-        var validator = new PolicyValidator();
-        var payload = generateBasicPayload();
-        var envOverrides = new HashMap<>(payload.getEnvOverrides());
-        envOverrides.put(PolicyValidator.ENV_ENVIRONMENT, "integ");
-        envOverrides.put(PolicyValidator.ENV_CORE_ENDPOINT, "coreendpoint");
         payload = payload.toBuilder()
                 .envOverrides(envOverrides)
                 .build();
@@ -171,7 +158,9 @@ public class PolicyValidatorTest {
                 .restartPolicy("NEVER")
                 .envOverrides(Map.of(
                         PolicyValidator.ENV_ENVIRONMENT, "prod",
-                        PolicyValidator.ENV_OPERATOR_API_KEY_SECRET_NAME, "dummy_api_key"
+                        PolicyValidator.ENV_OPERATOR_API_KEY_SECRET_NAME, "dummy_api_key",
+                        PolicyValidator.ENV_CORE_ENDPOINT, "core_endpoint",
+                        PolicyValidator.ENV_OPT_OUT_ENDPOINT, "optout_endpoint"
                 ));
         return builder.build();
     }

--- a/src/test/java/com/uid2/shared/util/UrlEquivalenceValidatorTest.java
+++ b/src/test/java/com/uid2/shared/util/UrlEquivalenceValidatorTest.java
@@ -33,7 +33,8 @@ public class UrlEquivalenceValidatorTest {
             "https://example.com;https://example.COM/",
             "https://example.com;HTTPS://example.com/",
             "http://example.com:8080;http://example.com:8080/",
-            "http://example.com:8080   ;http://example.com:8080/"
+            "http://example.com:8080   ;http://example.com:8080/",
+            "https://ade7-113-29-30-226.ngrok-free.app;https://ade7-113-29-30-226.ngrok-free.app/attest"
     }, delimiter = ';')
     public void urls_equal(String first, String second) {
         Assert.assertTrue(UrlEquivalenceValidator.areUrlsEquivalent(first, second, loggerMock));

--- a/src/test/java/com/uid2/shared/util/UrlEquivalenceValidatorTest.java
+++ b/src/test/java/com/uid2/shared/util/UrlEquivalenceValidatorTest.java
@@ -1,0 +1,66 @@
+package com.uid2.shared.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+import org.junit.Assert;
+import org.mockito.Mock;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class UrlEquivalenceValidatorTest {
+
+    @Mock
+    private Logger loggerMock;
+
+    @BeforeEach
+    public void setup(){
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            "http://example.com;http://example.com/",
+            "https://example.com;https://example.com/",
+            "https://example.com;https://EXAMPLE.com/",
+            "https://example.com;https://example.COM/",
+            "https://example.com;HTTPS://example.com/",
+            "http://example.com:8080;http://example.com:8080/",
+            "http://example.com:8080   ;http://example.com:8080/"
+    }, delimiter = ';')
+    public void urls_equal(String first, String second) {
+        Assert.assertTrue(UrlEquivalenceValidator.areUrlsEquivalent(first, second, loggerMock));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            "http://example.com;https://example.com/",
+            "http://example.com;https://example.com/",
+            "https://example.com:8081;http://example.com:8081/",
+            "http://example1.com;http://example.com/",
+            "http://example.com;http://example1.com/",
+            "http://example.com:8081;http://example.com:8080/",
+            "http://example.com:8081;http://example.com:8080/",
+    }, delimiter = ';')
+    public void urls_not_equal(String first, String second) {
+        Assert.assertFalse(UrlEquivalenceValidator.areUrlsEquivalent(first, second, loggerMock));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            "http//example.com;http://example.com;URL could not be parsed to a valid URL. Given URL: http//example.com",
+            "http://example1.com;http//example2.com;URL could not be parsed to a valid URL. Given URL: http//example2.com",
+            "foo://example1.com;http://example2.com;URL could not be parsed to a valid URL. Given URL: foo://example1.com",
+            "http://example1.com;bar://example2.com;URL could not be parsed to a valid URL. Given URL: bar://example2.com",
+    }, delimiter = ';')
+    public void urls_invalid(String first, String second, String expectedError) {
+        Assert.assertFalse(UrlEquivalenceValidator.areUrlsEquivalent(first, second, loggerMock));
+        verify(loggerMock, times(1)).error(eq(expectedError), (Throwable) any());
+    }
+
+}

--- a/src/test/java/com/uid2/shared/util/UrlEquivalenceValidatorTest.java
+++ b/src/test/java/com/uid2/shared/util/UrlEquivalenceValidatorTest.java
@@ -26,6 +26,8 @@ public class UrlEquivalenceValidatorTest {
     @ParameterizedTest
     @CsvSource(value = {
             "http://example.com;http://example.com/",
+            "http://example.com/path1;http://example.com/path2",
+            "http://example.com/path1/path2;http://example.com/path2/path1",
             "https://example.com;https://example.com/",
             "https://example.com;https://EXAMPLE.com/",
             "https://example.com;https://example.COM/",
@@ -57,6 +59,7 @@ public class UrlEquivalenceValidatorTest {
             "http://example1.com;http//example2.com;URL could not be parsed to a valid URL. Given URL: http//example2.com",
             "foo://example1.com;http://example2.com;URL could not be parsed to a valid URL. Given URL: foo://example1.com",
             "http://example1.com;bar://example2.com;URL could not be parsed to a valid URL. Given URL: bar://example2.com",
+            "http://example1.com:abc;http://example2.com;URL could not be parsed to a valid URL. Given URL: http://example1.com:abc",
     }, delimiter = ';')
     public void urls_invalid(String first, String second, String expectedError) {
         Assert.assertFalse(UrlEquivalenceValidator.areUrlsEquivalent(first, second, loggerMock));

--- a/src/test/resources/com.uid2.shared/test/secure/gcpoidc/jwt_payload_policy_valid.json
+++ b/src/test/resources/com.uid2.shared/test/secure/gcpoidc/jwt_payload_policy_valid.json
@@ -28,7 +28,9 @@
       "image_id": "sha256:5be33a19451733a45ea1bdb340fcb858a0fc733e91ca0a0d99638652f6dcabd0",
       "env_override": {
         "DEPLOYMENT_ENVIRONMENT": "prod",
-        "API_TOKEN_SECRET_NAME": "dummy"
+        "API_TOKEN_SECRET_NAME": "dummy",
+        "CORE_BASE_URL": "core-url",
+        "OPTOUT_BASE_URL": "optout-url"
       },
       "cmd_override": null,
       "env": {


### PR DESCRIPTION
Tested with a local build of the AWS operator. 
With the correct URL: 
DEBUG c.u.s.s.NitroAttestationProvider - Checking URLs equivalent: URL1: 'https://ade7-113-29-30-226.ngrok-free.app', URL2: 'https://ade7-113-29-30-226.ngrok-free.app/attest'

With the incorrect URLs:
WARN  c.u.c.h.AttestationFailureHandler - Attestation failed. StatusCode=401 Reason=ATTESTATION_FAILURE Data={"reason":"The given attestation URL is unknown"} OperatorKeyHash=UpbIqh+uxkYA9a2Q6BkiuWtxDWpyuoLseFWIRhGkdgwiozfwe2+40RPawAJ7W/M5SIfKz6aUoz5RLv5WfIli0Q== OperatorKeyName=Local-AWS-Nitro SiteId=124 Protocol=aws-nitro OperatorType=PRIVATE OriginatingIpAddress=44.203.38.223

Trusted Operators are not checked, so this has no impact on them. 