### PR TITLE
add another catch block for initial s3 files creation error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.uid2</groupId>
     <artifactId>uid2-shared</artifactId>
-    <version>7.11.4</version>
+    <version>7.11.5-alpha-96-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Library for all the shared uid2 operations</description>
     <url>https://github.com/IABTechLab/uid2docs</url>

--- a/src/main/java/com/uid2/shared/cloud/CloudStorageS3.java
+++ b/src/main/java/com/uid2/shared/cloud/CloudStorageS3.java
@@ -132,7 +132,7 @@ public class CloudStorageS3 implements TaggableCloudStorage {
             return obj.getObjectContent();
         } catch (AmazonS3Exception e) {
             if (e.getErrorCode().equals("NoSuchKey")) {
-                throw new CloudStorageException("The specified key does not exist" + e.getClass().getSimpleName() + ": " + bucket);
+                throw new CloudStorageException("The specified key does not exist: " + e.getClass().getSimpleName() + ": " + bucket);
             } else {
                 throw new CloudStorageException("s3 get error: " + e.getClass().getSimpleName() + ": " + bucket);
             }

--- a/src/main/java/com/uid2/shared/cloud/CloudStorageS3.java
+++ b/src/main/java/com/uid2/shared/cloud/CloudStorageS3.java
@@ -130,6 +130,12 @@ public class CloudStorageS3 implements TaggableCloudStorage {
         try {
             S3Object obj = this.s3.getObject(bucket, cloudPath);
             return obj.getObjectContent();
+        } catch (AmazonS3Exception e) {
+            if (e.getErrorCode().equals("NoSuchKey")) {
+                throw new CloudStorageException("The specified key does not exist" + e.getClass().getSimpleName() + ": " + bucket);
+            } else {
+                throw new CloudStorageException("s3 get error: " + e.getClass().getSimpleName() + ": " + bucket);
+            }
         } catch (Throwable t) {
             // Do not log the message or the original exception as that may contain the pre-signed url
             throw new CloudStorageException("s3 get error: " + t.getClass().getSimpleName() + ": " + bucket);


### PR DESCRIPTION
Have tested that the new catch block correctly catches and throws the appropriate message for S3 file's initial creation.