### PR TITLE
Ignore CVE-2024-47535

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -2,4 +2,9 @@
 # See https://aquasecurity.github.io/trivy/v0.35/docs/vulnerability/examples/filter/ 
 # for more details
 # e.g. 
+
+# https://thetradedesk.atlassian.net/browse/UID2-4460
 CVE-2024-47535
+
+# https://thetradedesk.atlassian.net/browse/UID2-4461
+CVE-2024-7254

--- a/.trivyignore
+++ b/.trivyignore
@@ -2,4 +2,4 @@
 # See https://aquasecurity.github.io/trivy/v0.35/docs/vulnerability/examples/filter/ 
 # for more details
 # e.g. 
-# CVE-2022-3996
+CVE-2024-47535

--- a/pom.xml
+++ b/pom.xml
@@ -58,9 +58,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <vertx.version>4.3.8</vertx.version>
+        <vertx.version>4.5.3</vertx.version>
         <!-- check micrometer.version vertx-micrometer-metrics consumes before bumping up -->
-        <micrometer.version>1.1.0</micrometer.version>
+        <micrometer.version>1.12.2</micrometer.version>
         <image.version>${project.version}</image.version>
     </properties>
     <dependencyManagement>
@@ -194,19 +194,9 @@
             <version>3.15.12</version>
         </dependency>
         <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-            <version>3.25.5</version>
-        </dependency>
-        <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-security-attestation</artifactId>
             <version>1.1.29</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http2</artifactId>
-            <version>4.1.100.Final</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-logging</artifactId>
-            <version>3.15.12</version>
+            <version>3.20.6</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>


### PR DESCRIPTION
Remove the overrides of dependencies
Update Vertx to the same as is being used by all the other services.