### PR TITLE
sch-UID2-4073 high level tests for path normalisation in metrics

### DIFF
--- a/src/main/java/com/uid2/shared/util/HTTPPathMetricFilter.java
+++ b/src/main/java/com/uid2/shared/util/HTTPPathMetricFilter.java
@@ -1,0 +1,19 @@
+package com.uid2.shared.util;
+
+import io.vertx.core.http.impl.HttpUtils;
+import java.util.Set;
+
+public class HTTPPathMetricFilter {
+    public static String filterPath(String actualPath, Set<String> pathSet) {
+        try {
+            String normalized = HttpUtils.normalizePath(actualPath).split("\\?")[0];
+            if (normalized.charAt(normalized.length() - 1) == '/') {
+                normalized = normalized.substring(0, normalized.length() - 1);
+            }
+            normalized = normalized.toLowerCase();
+            return pathSet == null || pathSet.isEmpty() || pathSet.contains(normalized) ? normalized : "/unknown";
+        } catch (IllegalArgumentException e) {
+            return "/parsing_error";
+        }
+    }
+}

--- a/src/test/java/com/uid2/shared/util/HTTPPathMetricFilterTest.java
+++ b/src/test/java/com/uid2/shared/util/HTTPPathMetricFilterTest.java
@@ -1,0 +1,53 @@
+package com.uid2.shared.util;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class HTTPPathMetricFilterTest {
+    final Set<String> pathSet = Set.of("/v1/identity/map", "/token/refresh");
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "",
+            "/",
+            "/unknown-path",
+            "../",
+            "/v1/identity/map%55",
+    })
+    void testPathFiltering_InvalidPaths_Unknown(String actualPath) {
+        String filteredPath = HTTPPathMetricFilter.filterPath(actualPath, pathSet);
+        assertEquals("/unknown", filteredPath);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "v1/identity/map?id=bad-escape-code%2",
+            "token/refresh?refresh_token=SOME_TOKEN<%=7485*4353%>",
+    })
+    void testPathFiltering_InvalidPaths_ParsingError(String actualPath) {
+        String filteredPath = HTTPPathMetricFilter.filterPath(actualPath, pathSet);
+        assertEquals("/parsing_error", filteredPath);
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            "/v1/identity/map, /v1/identity/map",
+            "v1/identity/map, /v1/identity/map",
+            "V1/IdenTity/mAp, /v1/identity/map",
+            "./v1//identity//map/, /v1/identity/map",
+            "../v1/identity/./map, /v1/identity/map",
+            "/v1/identity/new/path/../../map, /v1/identity/map",
+            "token/refresh?refresh_token=123%20%23, /token/refresh",
+            "v1/identity/map?identity/../map/, /v1/identity/map",
+
+    })
+    void testPathFiltering_ValidPaths_KnownEndpoints(String actualPath, String expectedFilteredPath) {
+        String filteredPath = HTTPPathMetricFilter.filterPath(actualPath, pathSet);
+        assertEquals(expectedFilteredPath, filteredPath);
+    }
+}


### PR DESCRIPTION
Most of the uid2 Vertx apps filter out junk paths from Prometheus metrics with a predefined meter filter, however:
- This meter filter logic is duplicated in all our services
- There’s no test coverage for the meter filter logic
- There’s a bug in this filter where if a path has bad encoding, an IllegalArgumentException is thrown, causing us to put the junk path in our metrics

Here, the path normalisation and filtering have been refactored into Shared so it can be used by all apps.
High level tests have been created to ensure the intended behaviour:
- paths that have invalid encoding are filtered as a new bucket '/parsing_error'
- paths that match those in a valid path set are normalised
- paths that do not match those in a valid set are filtered as '/unknown'
