### PR TITLE
Enabled filtering for paths with params for metrics

### DIFF
--- a/src/main/java/com/uid2/shared/util/HTTPPathMetricFilter.java
+++ b/src/main/java/com/uid2/shared/util/HTTPPathMetricFilter.java
@@ -11,7 +11,16 @@ public class HTTPPathMetricFilter {
                 normalized = normalized.substring(0, normalized.length() - 1);
             }
             normalized = normalized.toLowerCase();
-            return pathSet == null || pathSet.isEmpty() || pathSet.contains(normalized) ? normalized : "/unknown";
+
+            if (pathSet == null || pathSet.isEmpty()) { return normalized; }
+
+            for (String path : pathSet) {
+                String pathRegex = path.replaceAll(":[^/]+", "[^/]+");
+                if (normalized.matches(pathRegex)) {
+                    return path;
+                }
+            }
+            return "/unknown";
         } catch (IllegalArgumentException e) {
             return "/parsing_error";
         }

--- a/src/test/java/com/uid2/shared/util/HTTPPathMetricFilterTest.java
+++ b/src/test/java/com/uid2/shared/util/HTTPPathMetricFilterTest.java
@@ -9,7 +9,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class HTTPPathMetricFilterTest {
-    final Set<String> pathSet = Set.of("/v1/identity/map", "/token/refresh");
+    final Set<String> pathSet = Set.of("/v1/identity/map", "/token/refresh", "/list", "/list/:siteId/:keyId");
 
     @ParameterizedTest
     @ValueSource(strings = {
@@ -18,6 +18,7 @@ public class HTTPPathMetricFilterTest {
             "/unknown-path",
             "../",
             "/v1/identity/map%55",
+            "/list/123",
     })
     void testPathFiltering_InvalidPaths_Unknown(String actualPath) {
         String filteredPath = HTTPPathMetricFilter.filterPath(actualPath, pathSet);
@@ -28,6 +29,7 @@ public class HTTPPathMetricFilterTest {
     @ValueSource(strings = {
             "v1/identity/map?id=bad-escape-code%2",
             "token/refresh?refresh_token=SOME_TOKEN<%=7485*4353%>",
+            "list/12%4/5435"
     })
     void testPathFiltering_InvalidPaths_ParsingError(String actualPath) {
         String filteredPath = HTTPPathMetricFilter.filterPath(actualPath, pathSet);
@@ -44,6 +46,8 @@ public class HTTPPathMetricFilterTest {
             "/v1/identity/new/path/../../map, /v1/identity/map",
             "token/refresh?refresh_token=123%20%23, /token/refresh",
             "v1/identity/map?identity/../map/, /v1/identity/map",
+            "/list, /list",
+            "/list/123/key123, /list/:siteId/:keyId"
 
     })
     void testPathFiltering_ValidPaths_KnownEndpoints(String actualPath, String expectedFilteredPath) {


### PR DESCRIPTION
As some http endpoints contain path parameters, we want to be able to filter paths correctly into these endpoints.