### PR TITLE
Rotating Runtime Config Store 

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -5,3 +5,6 @@
 
 # https://thetradedesk.atlassian.net/browse/UID2-4460
 CVE-2024-47535
+
+# https://thetradedesk.atlassian.net/browse/UID2-4874
+CVE-2025-24970

--- a/src/main/java/com/uid2/shared/store/RotatingRuntimeConfigStore.java
+++ b/src/main/java/com/uid2/shared/store/RotatingRuntimeConfigStore.java
@@ -1,0 +1,39 @@
+package com.uid2.shared.store;
+
+import com.uid2.shared.Utils;
+import com.uid2.shared.cloud.DownloadCloudStorage;
+import com.uid2.shared.store.reader.IMetadataVersionedStore;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+import java.io.InputStream;
+
+public class RotatingRuntimeConfigStore implements IMetadataVersionedStore {
+    private final DownloadCloudStorage metadataStreamProvider;
+    private final String runtimeConfigPath;
+    private final Vertx vertx;
+
+    public RotatingRuntimeConfigStore(Vertx vertx, DownloadCloudStorage metadataStreamProvider, String runtimeConfigPath) {
+        this.metadataStreamProvider = metadataStreamProvider;
+        this.runtimeConfigPath = runtimeConfigPath;
+        this.vertx = vertx;
+    }
+
+    @Override
+    public JsonObject getMetadata() throws Exception {
+        try (InputStream s = this.metadataStreamProvider.download(this.runtimeConfigPath)) {
+            return Utils.toJsonObject(s);
+        }
+    }
+
+    @Override
+    public long getVersion(JsonObject jsonObject) {
+        return jsonObject.getLong("version");
+    }
+
+    @Override
+    public long loadContent(JsonObject jsonObject) throws Exception {
+        vertx.eventBus().publish("operator.runtime.config", jsonObject);
+        return 1;
+    }
+}

--- a/src/test/java/com/uid2/shared/store/RotatingRuntimeConfigStoreTest.java
+++ b/src/test/java/com/uid2/shared/store/RotatingRuntimeConfigStoreTest.java
@@ -1,0 +1,67 @@
+package com.uid2.shared.store;
+
+import com.uid2.shared.cloud.ICloudStorage;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.json.JsonObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import io.vertx.core.Vertx;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class RotatingRuntimeConfigStoreTest {
+    private AutoCloseable mocks;
+    @Mock
+    private ICloudStorage metadataStreamProvider;
+    @Mock
+    private Vertx vertx;
+    @Mock
+    private EventBus eventBus;
+
+    private RotatingRuntimeConfigStore rotatingRuntimeConfigStore;
+    private final String runtimeConfigPath = "path/to/config";
+
+    @BeforeEach
+    public void setup() {
+        mocks = MockitoAnnotations.openMocks(this);
+        when(vertx.eventBus()).thenReturn(eventBus);
+        rotatingRuntimeConfigStore = new RotatingRuntimeConfigStore(vertx, metadataStreamProvider, runtimeConfigPath);
+    }
+
+    @AfterEach
+    public void teardown() throws Exception {
+        mocks.close();
+    }
+
+    @Test
+    public void testGetMetadata() throws Exception {
+        JsonObject expectedMetadata = new JsonObject().put("key", "value");
+        when(metadataStreamProvider.download(runtimeConfigPath))
+                .thenReturn(new ByteArrayInputStream(expectedMetadata.toString().getBytes(StandardCharsets.US_ASCII)));
+        JsonObject actualMetadata = rotatingRuntimeConfigStore.getMetadata();
+        assertEquals(expectedMetadata, actualMetadata);
+    }
+
+    @Test
+    public void testGetVersion() {
+        JsonObject jsonObject = new JsonObject().put("version", 123L);
+        long version = rotatingRuntimeConfigStore.getVersion(jsonObject);
+        assertEquals(123L, version);
+    }
+
+    @Test
+    public void testLoadContent() throws Exception {
+        JsonObject jsonObject = new JsonObject().put("key", "value");
+        long result = rotatingRuntimeConfigStore.loadContent(jsonObject);
+        verify(eventBus).publish("operator.runtime.config", jsonObject);
+        assertEquals(1L, result);
+    }
+
+}


### PR DESCRIPTION
- Add RotatingRuntimeConfigStore for retrieving operator runtime config from core `/operator/config` attested endpoint