### PR TITLE
Consolidated ObjectMapper configs

### DIFF
--- a/src/main/java/com/uid2/shared/Utils.java
+++ b/src/main/java/com/uid2/shared/Utils.java
@@ -34,7 +34,7 @@ public class Utils {
     public static int getPortOffset() {
         // read port_offset from env, the reason this can't be read from vertx-config
         // is Prometheus port needs to be specified before vertx creation
-        final String val = System.getenv("port_offset");
+        String val = System.getenv("port_offset");
         return val != null ? Integer.parseInt(val) : 0;
     }
 

--- a/src/main/java/com/uid2/shared/Utils.java
+++ b/src/main/java/com/uid2/shared/Utils.java
@@ -179,8 +179,8 @@ public class Utils {
     }
 
     public static InputStream convertHttpResponseToInputStream(HttpResponse<String> httpResponse) {
-        final String responseBody = httpResponse.body();
-        final byte[] responseBytes = responseBody.getBytes();
+        String responseBody = httpResponse.body();
+        byte[] responseBytes = responseBody.getBytes();
         return new ByteArrayInputStream(responseBytes);
     }
     public static MessageDigest createMessageDigestSHA512() {

--- a/src/main/java/com/uid2/shared/Utils.java
+++ b/src/main/java/com/uid2/shared/Utils.java
@@ -28,20 +28,14 @@ public class Utils {
 
     public static boolean isProductionEnvironment() {
         // detect if it is running in KUBERNETES_SERVICE_HOST
-        if (System.getenv("KUBERNETES_SERVICE_HOST") == null) {
-            return false;
-        } else {
-            return true;
-        }
+        return System.getenv("KUBERNETES_SERVICE_HOST") != null;
     }
 
     public static int getPortOffset() {
         // read port_offset from env, the reason this can't be read from vertx-config
         // is Prometheus port needs to be specified before vertx creation
         String val = System.getenv("port_offset");
-        int portOffset = 0;
-        if (val != null) portOffset = Integer.valueOf(val);
-        return portOffset;
+        return val != null ? Integer.parseInt(val) : 0;
     }
 
     public static boolean ensureDirectoryExists(String dir) {
@@ -75,10 +69,10 @@ public class Utils {
     }
 
     public static String readToEnd(InputStream stream) throws IOException {
-        final InputStreamReader reader = new InputStreamReader(stream);
-        final char[] buff = new char[1024];
-        final StringBuilder sb = new StringBuilder();
-        for (int count; (count = reader.read(buff, 0, buff.length)) > 0; ) {
+        InputStreamReader reader = new InputStreamReader(stream);
+        char[] buff = new char[1024];
+        StringBuilder sb = new StringBuilder();
+        for (int count; (count = reader.read(buff, 0, buff.length)) > 0;) {
             sb.append(buff, 0, count);
         }
         return sb.toString();

--- a/src/main/java/com/uid2/shared/Utils.java
+++ b/src/main/java/com/uid2/shared/Utils.java
@@ -34,7 +34,7 @@ public class Utils {
     public static int getPortOffset() {
         // read port_offset from env, the reason this can't be read from vertx-config
         // is Prometheus port needs to be specified before vertx creation
-        String val = System.getenv("port_offset");
+        final String val = System.getenv("port_offset");
         return val != null ? Integer.parseInt(val) : 0;
     }
 
@@ -69,9 +69,9 @@ public class Utils {
     }
 
     public static String readToEnd(InputStream stream) throws IOException {
-        InputStreamReader reader = new InputStreamReader(stream);
-        char[] buff = new char[1024];
-        StringBuilder sb = new StringBuilder();
+        final InputStreamReader reader = new InputStreamReader(stream);
+        final char[] buff = new char[1024];
+        final StringBuilder sb = new StringBuilder();
         for (int count; (count = reader.read(buff, 0, buff.length)) > 0;) {
             sb.append(buff, 0, count);
         }
@@ -85,7 +85,6 @@ public class Utils {
         while ((nRead = stream.read(data, 0, data.length)) != -1) {
             buffer.write(data, 0, nRead);
         }
-
         buffer.flush();
         return buffer.toByteArray();
     }
@@ -180,10 +179,8 @@ public class Utils {
     }
 
     public static InputStream convertHttpResponseToInputStream(HttpResponse<String> httpResponse) {
-        String responseBody = httpResponse.body();
-
-        byte[] responseBytes = responseBody.getBytes();
-
+        final String responseBody = httpResponse.body();
+        final byte[] responseBytes = responseBody.getBytes();
         return new ByteArrayInputStream(responseBytes);
     }
     public static MessageDigest createMessageDigestSHA512() {

--- a/src/main/java/com/uid2/shared/auth/RotatingOperatorKeyProvider.java
+++ b/src/main/java/com/uid2/shared/auth/RotatingOperatorKeyProvider.java
@@ -27,7 +27,6 @@ public class RotatingOperatorKeyProvider implements IOperatorKeyProvider, IMetad
     private final StoreScope scope;
     private final AuthorizableStore<OperatorKey> operatorKeyStore;
 
-
     public RotatingOperatorKeyProvider(DownloadCloudStorage metadataStreamProvider, DownloadCloudStorage contentStreamProvider, StoreScope scope) {
         this.metadataStreamProvider = metadataStreamProvider;
         this.contentStreamProvider = contentStreamProvider;
@@ -65,7 +64,7 @@ public class RotatingOperatorKeyProvider implements IOperatorKeyProvider, IMetad
         String operatorKeysJson = CharStreams.toString(new InputStreamReader(contentStream, Charsets.UTF_8));
         List<OperatorKey> operatorKeys = Arrays.asList(OBJECT_MAPPER.readValue(operatorKeysJson, OperatorKey[].class));
         operatorKeyStore.refresh(operatorKeys);
-        LOGGER.info("Loaded " + operatorKeys.size() + " operator profiles");
+        LOGGER.info("Loaded {} operator profiles", operatorKeys.size());
         return operatorKeys.size();
     }
 

--- a/src/main/java/com/uid2/shared/optout/OptOutFileMetadata.java
+++ b/src/main/java/com/uid2/shared/optout/OptOutFileMetadata.java
@@ -3,9 +3,10 @@ package com.uid2.shared.optout;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.uid2.shared.util.Mapper;
 
 public class OptOutFileMetadata {
-    private static ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = Mapper.getInstance();
 
     @JsonProperty("type")
     public String type;
@@ -21,7 +22,7 @@ public class OptOutFileMetadata {
 
     public static OptOutFileMetadata fromJsonString(String str) {
         try {
-            return OptOutFileMetadata.mapper.readValue(str, OptOutFileMetadata.class);
+            return OptOutFileMetadata.OBJECT_MAPPER.readValue(str, OptOutFileMetadata.class);
         } catch (JsonProcessingException ex) {
             // OptOutFileMetadata is an internal message, any serialization and deserialization exception is logic error
             // return null here
@@ -31,12 +32,11 @@ public class OptOutFileMetadata {
 
     public String toJsonString() {
         try {
-            return OptOutFileMetadata.mapper.writeValueAsString(this);
+            return OptOutFileMetadata.OBJECT_MAPPER.writeValueAsString(this);
         } catch (JsonProcessingException ex) {
             // OptOutFileMetadata is an internal message, any serialization and deserialization exception is logic error
             // return null here
             return null;
         }
     }
-
 }

--- a/src/main/java/com/uid2/shared/optout/OptOutMetadata.java
+++ b/src/main/java/com/uid2/shared/optout/OptOutMetadata.java
@@ -3,11 +3,12 @@ package com.uid2.shared.optout;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.uid2.shared.util.Mapper;
 
 import java.util.Collection;
 
 public class OptOutMetadata {
-    private static ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER = Mapper.getInstance();
 
     @JsonProperty("version")
     public long version;
@@ -20,7 +21,7 @@ public class OptOutMetadata {
 
     public static OptOutMetadata fromJsonString(String str) {
         try {
-            return OptOutMetadata.mapper.readValue(str, OptOutMetadata.class);
+            return OptOutMetadata.OBJECT_MAPPER.readValue(str, OptOutMetadata.class);
         } catch (JsonProcessingException ex) {
             // OptOutMetadata is an internal message, any serialization and deserialization exception is logic error
             // return null here
@@ -30,7 +31,7 @@ public class OptOutMetadata {
 
     public String toJsonString() {
         try {
-            return OptOutMetadata.mapper.writeValueAsString(this);
+            return OptOutMetadata.OBJECT_MAPPER.writeValueAsString(this);
         } catch (JsonProcessingException ex) {
             // OptOutMetadata is an internal message, any serialization and deserialization exception is logic error
             // return null here

--- a/src/main/java/com/uid2/shared/optout/OptOutUtils.java
+++ b/src/main/java/com/uid2/shared/optout/OptOutUtils.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.uid2.shared.Const;
 import com.uid2.shared.Utils;
 import com.uid2.shared.cloud.CloudUtils;
+import com.uid2.shared.util.Mapper;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -28,14 +29,15 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public class OptOutUtils {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OptOutUtils.class);
+    private static final ObjectMapper OBJECT_MAPPER = Mapper.getInstance();
+
     // delta file name pattern: optout-delta-<replica_id>_yyyy-MM-ddTHH:mm:ssZ.dat
     public static final String prefixDeltaFile = "optout-delta-";
     // partition file name pattern: optout-partition-<replica_id>_yyyy-MM-ddTHH:MM:SSZ.dat
     public static final String prefixPartitionFile = "optout-partition-";
-    private static final Logger LOGGER = LoggerFactory.getLogger(OptOutUtils.class);
 
     public static Random rand = new Random();
-    public static ObjectMapper mapper = new ObjectMapper();
     public static String tmpDir = System.getProperty("java.io.tmpdir");
 
     public static Base64.Encoder base64Encoder = Base64.getEncoder();
@@ -93,7 +95,7 @@ public class OptOutUtils {
         byte[] data = new byte[len / 2];
         for (int i = 0; i < len; i += 2) {
             data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
-                + Character.digit(s.charAt(i + 1), 16));
+                    + Character.digit(s.charAt(i + 1), 16));
         }
         return data;
     }
@@ -130,7 +132,7 @@ public class OptOutUtils {
 
     public static String[] jsonArrayToStringArray(String json) {
         try {
-            return mapper.readValue(json, String[].class);
+            return OBJECT_MAPPER.readValue(json, String[].class);
         } catch (Exception ex) {
             // this is internal message and not expected to be invalid, returning null
             return null;
@@ -143,7 +145,7 @@ public class OptOutUtils {
 
     public static String toJson(Collection<String> strs) {
         try {
-            return mapper.writeValueAsString(strs);
+            return OBJECT_MAPPER.writeValueAsString(strs);
         } catch (Exception ex) {
             // this is internal message and not expected to be invalid, returning null
             return null;
@@ -520,9 +522,9 @@ public class OptOutUtils {
     // last partition file timestamp
     public static Instant lastPartitionTimestamp(Collection<String> collection) {
         Optional<Instant> tsOfLast = collection.stream()
-            .filter(p -> OptOutUtils.isPartitionFile(p))
-            .map(OptOutUtils::getFileTimestamp)
-            .sorted(Comparator.reverseOrder()).findFirst();
+                .filter(p -> OptOutUtils.isPartitionFile(p))
+                .map(OptOutUtils::getFileTimestamp)
+                .sorted(Comparator.reverseOrder()).findFirst();
 
         return tsOfLast.isPresent() ? tsOfLast.get() : Instant.EPOCH;
     }
@@ -543,11 +545,11 @@ public class OptOutUtils {
 
     public static String getDeltaConsumerDir(JsonObject config) {
         return String.format("%sconsumer/delta",
-            CloudUtils.normalizDirPath(config.getString(Const.Config.OptOutDataDirProp)));
+                CloudUtils.normalizDirPath(config.getString(Const.Config.OptOutDataDirProp)));
     }
 
     public static String getPartitionConsumerDir(JsonObject config) {
         return String.format("%sconsumer/partition",
-            CloudUtils.normalizDirPath(config.getString(Const.Config.OptOutDataDirProp)));
+                CloudUtils.normalizDirPath(config.getString(Const.Config.OptOutDataDirProp)));
     }
 }

--- a/src/main/java/com/uid2/shared/store/parser/ClientParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/ClientParser.java
@@ -14,7 +14,7 @@ public class ClientParser implements Parser<Collection<ClientKey>> {
 
     @Override
     public ParsingResult<Collection<ClientKey>> deserialize(InputStream inputStream) throws IOException {
-        ClientKey[] clientKeys = OBJECT_MAPPER.readValue(inputStream, ClientKey[].class);
+        final ClientKey[] clientKeys = OBJECT_MAPPER.readValue(inputStream, ClientKey[].class);
         return new ParsingResult<>(Arrays.asList(clientKeys), clientKeys.length);
     }
 }

--- a/src/main/java/com/uid2/shared/store/parser/ClientParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/ClientParser.java
@@ -14,7 +14,7 @@ public class ClientParser implements Parser<Collection<ClientKey>> {
 
     @Override
     public ParsingResult<Collection<ClientKey>> deserialize(InputStream inputStream) throws IOException {
-        final ClientKey[] clientKeys = OBJECT_MAPPER.readValue(inputStream, ClientKey[].class);
+        ClientKey[] clientKeys = OBJECT_MAPPER.readValue(inputStream, ClientKey[].class);
         return new ParsingResult<>(Arrays.asList(clientKeys), clientKeys.length);
     }
 }

--- a/src/main/java/com/uid2/shared/store/parser/ClientParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/ClientParser.java
@@ -1,6 +1,5 @@
 package com.uid2.shared.store.parser;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.uid2.shared.auth.ClientKey;
 import com.uid2.shared.util.Mapper;
@@ -12,10 +11,6 @@ import java.util.Collection;
 
 public class ClientParser implements Parser<Collection<ClientKey>> {
     private static final ObjectMapper OBJECT_MAPPER = Mapper.getInstance();
-
-    static {
-        OBJECT_MAPPER.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
-    }
 
     @Override
     public ParsingResult<Collection<ClientKey>> deserialize(InputStream inputStream) throws IOException {

--- a/src/main/java/com/uid2/shared/store/parser/ClientSideKeypairParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/ClientSideKeypairParser.java
@@ -1,6 +1,5 @@
 package com.uid2.shared.store.parser;
 
-import com.uid2.shared.Const;
 import com.uid2.shared.Utils;
 import com.uid2.shared.model.ClientSideKeypair;
 import com.uid2.shared.store.ClientSideKeypairStoreSnapshot;
@@ -8,7 +7,6 @@ import com.uid2.shared.store.IClientSideKeypairStore;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
-import java.io.Console;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.Instant;
@@ -17,18 +15,22 @@ import java.util.*;
 public class ClientSideKeypairParser implements Parser<IClientSideKeypairStore.IClientSideKeypairStoreSnapshot> {
     @Override
     public ParsingResult<IClientSideKeypairStore.IClientSideKeypairStoreSnapshot> deserialize(InputStream inputStream) throws IOException {
-        JsonArray keypairsSpec = Utils.toJsonArray(inputStream);
+        final JsonArray keypairsSpec = Utils.toJsonArray(inputStream);
+
         final HashMap<String, ClientSideKeypair> keypairMap = new HashMap<>();
         final HashMap<Integer, List<ClientSideKeypair>> siteKeypairMap = new HashMap<>();
-        for (int i = 0; i < keypairsSpec.size(); i++){
-            JsonObject pairSpec = keypairsSpec.getJsonObject(i);
-            String subscriptionId = pairSpec.getString("subscription_id");
-            int siteId = pairSpec.getInteger("site_id");
-            String contact = pairSpec.getString("contact");
-            boolean disabled = pairSpec.getBoolean("disabled");
-            String name = pairSpec.getString("name", "");
-            Instant created = Instant.ofEpochSecond(pairSpec.getLong("created"));
-            ClientSideKeypair keypair = new ClientSideKeypair(
+
+        for (int i = 0; i < keypairsSpec.size(); i++) {
+            final JsonObject pairSpec = keypairsSpec.getJsonObject(i);
+
+            final String subscriptionId = pairSpec.getString("subscription_id");
+            final int siteId = pairSpec.getInteger("site_id");
+            final String contact = pairSpec.getString("contact");
+            final boolean disabled = pairSpec.getBoolean("disabled");
+            final String name = pairSpec.getString("name", "");
+            final Instant created = Instant.ofEpochSecond(pairSpec.getLong("created"));
+
+            final ClientSideKeypair keypair = new ClientSideKeypair(
                     subscriptionId,
                     pairSpec.getString("public_key"),
                     pairSpec.getString("private_key"),
@@ -38,10 +40,12 @@ public class ClientSideKeypairParser implements Parser<IClientSideKeypairStore.I
                     disabled,
                     name
             );
+
             keypairMap.put(subscriptionId, keypair);
             siteKeypairMap.computeIfAbsent(siteId, id -> new ArrayList<>()).add(keypair);
         }
-        ClientSideKeypairStoreSnapshot snapshot = new ClientSideKeypairStoreSnapshot(keypairMap, siteKeypairMap);
+
+        final ClientSideKeypairStoreSnapshot snapshot = new ClientSideKeypairStoreSnapshot(keypairMap, siteKeypairMap);
         return new ParsingResult<>(snapshot, keypairsSpec.size());
     }
 }

--- a/src/main/java/com/uid2/shared/store/parser/ClientSideKeypairParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/ClientSideKeypairParser.java
@@ -15,22 +15,21 @@ import java.util.*;
 public class ClientSideKeypairParser implements Parser<IClientSideKeypairStore.IClientSideKeypairStoreSnapshot> {
     @Override
     public ParsingResult<IClientSideKeypairStore.IClientSideKeypairStoreSnapshot> deserialize(InputStream inputStream) throws IOException {
-        final JsonArray keypairsSpec = Utils.toJsonArray(inputStream);
+        JsonArray keypairsSpec = Utils.toJsonArray(inputStream);
 
         final HashMap<String, ClientSideKeypair> keypairMap = new HashMap<>();
         final HashMap<Integer, List<ClientSideKeypair>> siteKeypairMap = new HashMap<>();
 
         for (int i = 0; i < keypairsSpec.size(); i++) {
-            final JsonObject pairSpec = keypairsSpec.getJsonObject(i);
+            JsonObject pairSpec = keypairsSpec.getJsonObject(i);
+            String subscriptionId = pairSpec.getString("subscription_id");
+            int siteId = pairSpec.getInteger("site_id");
+            String contact = pairSpec.getString("contact");
+            boolean disabled = pairSpec.getBoolean("disabled");
+            String name = pairSpec.getString("name", "");
+            Instant created = Instant.ofEpochSecond(pairSpec.getLong("created"));
 
-            final String subscriptionId = pairSpec.getString("subscription_id");
-            final int siteId = pairSpec.getInteger("site_id");
-            final String contact = pairSpec.getString("contact");
-            final boolean disabled = pairSpec.getBoolean("disabled");
-            final String name = pairSpec.getString("name", "");
-            final Instant created = Instant.ofEpochSecond(pairSpec.getLong("created"));
-
-            final ClientSideKeypair keypair = new ClientSideKeypair(
+            ClientSideKeypair keypair = new ClientSideKeypair(
                     subscriptionId,
                     pairSpec.getString("public_key"),
                     pairSpec.getString("private_key"),
@@ -45,7 +44,7 @@ public class ClientSideKeypairParser implements Parser<IClientSideKeypairStore.I
             siteKeypairMap.computeIfAbsent(siteId, id -> new ArrayList<>()).add(keypair);
         }
 
-        final ClientSideKeypairStoreSnapshot snapshot = new ClientSideKeypairStoreSnapshot(keypairMap, siteKeypairMap);
+        ClientSideKeypairStoreSnapshot snapshot = new ClientSideKeypairStoreSnapshot(keypairMap, siteKeypairMap);
         return new ParsingResult<>(snapshot, keypairsSpec.size());
     }
 }

--- a/src/main/java/com/uid2/shared/store/parser/CloudEncryptionKeyParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/CloudEncryptionKeyParser.java
@@ -15,8 +15,8 @@ public class CloudEncryptionKeyParser implements Parser<Map<Integer, CloudEncryp
 
     @Override
     public ParsingResult<Map<Integer, CloudEncryptionKey>> deserialize(InputStream inputStream) throws IOException {
-        CloudEncryptionKey[] cloudEncryptionKeys = OBJECT_MAPPER.readValue(inputStream, CloudEncryptionKey[].class);
-        Map<Integer, CloudEncryptionKey> cloudEncryptionKeysMap = Arrays.stream(cloudEncryptionKeys)
+        final CloudEncryptionKey[] cloudEncryptionKeys = OBJECT_MAPPER.readValue(inputStream, CloudEncryptionKey[].class);
+        final Map<Integer, CloudEncryptionKey> cloudEncryptionKeysMap = Arrays.stream(cloudEncryptionKeys)
                 .collect(Collectors.toMap(CloudEncryptionKey::getId, s -> s));
         return new ParsingResult<>(cloudEncryptionKeysMap, cloudEncryptionKeysMap.size());
     }

--- a/src/main/java/com/uid2/shared/store/parser/CloudEncryptionKeyParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/CloudEncryptionKeyParser.java
@@ -15,8 +15,8 @@ public class CloudEncryptionKeyParser implements Parser<Map<Integer, CloudEncryp
 
     @Override
     public ParsingResult<Map<Integer, CloudEncryptionKey>> deserialize(InputStream inputStream) throws IOException {
-        final CloudEncryptionKey[] cloudEncryptionKeys = OBJECT_MAPPER.readValue(inputStream, CloudEncryptionKey[].class);
-        final Map<Integer, CloudEncryptionKey> cloudEncryptionKeysMap = Arrays.stream(cloudEncryptionKeys)
+        CloudEncryptionKey[] cloudEncryptionKeys = OBJECT_MAPPER.readValue(inputStream, CloudEncryptionKey[].class);
+        Map<Integer, CloudEncryptionKey> cloudEncryptionKeysMap = Arrays.stream(cloudEncryptionKeys)
                 .collect(Collectors.toMap(CloudEncryptionKey::getId, s -> s));
         return new ParsingResult<>(cloudEncryptionKeysMap, cloudEncryptionKeysMap.size());
     }

--- a/src/main/java/com/uid2/shared/store/parser/KeyAclParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/KeyAclParser.java
@@ -20,7 +20,6 @@ public class KeyAclParser implements Parser<AclSnapshot> {
 
         for(int i = 0; i < aclsSpec.size(); ++i) {
             final JsonObject aclSpec = aclsSpec.getJsonObject(i);
-
             final Integer siteId = aclSpec.getInteger("site_id");
             final JsonArray blacklistSpec = aclSpec.getJsonArray("blacklist");
             final JsonArray whitelistSpec = aclSpec.getJsonArray("whitelist");
@@ -36,7 +35,9 @@ public class KeyAclParser implements Parser<AclSnapshot> {
                 accessList.add(accessListSpec.getInteger(j));
             }
 
-            aclMap.put(siteId, new EncryptionKeyAcl(isWhitelist, accessList));
+            EncryptionKeyAcl acl = new EncryptionKeyAcl(isWhitelist, accessList);
+
+            aclMap.put(siteId, acl);
         }
 
         return new ParsingResult<>(new AclSnapshot(aclMap), aclsSpec.size());

--- a/src/main/java/com/uid2/shared/store/parser/KeyAclParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/KeyAclParser.java
@@ -15,16 +15,19 @@ public class KeyAclParser implements Parser<AclSnapshot> {
     @Override
     public ParsingResult<AclSnapshot> deserialize(InputStream inputStream) throws IOException {
         final JsonArray aclsSpec = Utils.toJsonArray(inputStream);
+
         final HashMap<Integer, EncryptionKeyAcl> aclMap = new HashMap<>();
+
         for(int i = 0; i < aclsSpec.size(); ++i) {
             final JsonObject aclSpec = aclsSpec.getJsonObject(i);
+
             final Integer siteId = aclSpec.getInteger("site_id");
             final JsonArray blacklistSpec = aclSpec.getJsonArray("blacklist");
             final JsonArray whitelistSpec = aclSpec.getJsonArray("whitelist");
             if(blacklistSpec == null && whitelistSpec == null) {
                 continue;
             } else if (blacklistSpec != null && whitelistSpec != null) {
-                throw new IllegalStateException(String.format("Site %d has both blacklist and whitelist specified, this is not allowed"));
+                throw new IllegalStateException(String.format("Site %d has both blacklist and whitelist specified, this is not allowed", siteId));
             }
             final boolean isWhitelist = blacklistSpec == null;
             final JsonArray accessListSpec = isWhitelist ? whitelistSpec : blacklistSpec;

--- a/src/main/java/com/uid2/shared/store/parser/KeyParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/KeyParser.java
@@ -26,12 +26,12 @@ public class KeyParser implements Parser<IKeyStoreSnapshot> {
 
         for (int i = 0; i < keysSpec.size(); ++i) {
             JsonObject keySpec = keysSpec.getJsonObject(i);
+            int siteId = keySpec.getInteger("site_id");
+            Instant created = Instant.ofEpochSecond(keySpec.getLong("created"));
+            Instant activates = Instant.ofEpochSecond(keySpec.getLong("activates"));
+            Instant expires = Instant.ofEpochSecond(keySpec.getLong("expires"));
 
-            final int siteId = keySpec.getInteger("site_id");
-            final Instant created = Instant.ofEpochSecond(keySpec.getLong("created"));
-            final Instant activates = Instant.ofEpochSecond(keySpec.getLong("activates"));
-            final Instant expires = Instant.ofEpochSecond(keySpec.getLong("expires"));
-            final EncryptionKey key = new EncryptionKey(
+            EncryptionKey key = new EncryptionKey(
                     keySpec.getInteger("id"),
                     Base64.getDecoder().decode(keySpec.getString("secret")),
                     created, activates, expires, siteId);

--- a/src/main/java/com/uid2/shared/store/parser/KeyParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/KeyParser.java
@@ -17,23 +17,29 @@ import java.util.List;
 import static com.uid2.shared.store.IKeyStore.*;
 
 public class KeyParser implements Parser<IKeyStoreSnapshot> {
+    @Override
     public ParsingResult<IKeyStoreSnapshot> deserialize(InputStream inputStream) throws IOException {
-        JsonArray keysSpec = Utils.toJsonArray(inputStream);
+        final JsonArray keysSpec = Utils.toJsonArray(inputStream);
+
         final HashMap<Integer, EncryptionKey> keyMap = new HashMap<>();
         final HashMap<Integer, List<EncryptionKey>> siteKeyMap = new HashMap<>();
+
         for (int i = 0; i < keysSpec.size(); ++i) {
             JsonObject keySpec = keysSpec.getJsonObject(i);
-            int siteId = keySpec.getInteger("site_id");
-            Instant created = Instant.ofEpochSecond(keySpec.getLong("created"));
-            Instant activates = Instant.ofEpochSecond(keySpec.getLong("activates"));
-            Instant expires = Instant.ofEpochSecond(keySpec.getLong("expires"));
-            EncryptionKey key = new EncryptionKey(
+
+            final int siteId = keySpec.getInteger("site_id");
+            final Instant created = Instant.ofEpochSecond(keySpec.getLong("created"));
+            final Instant activates = Instant.ofEpochSecond(keySpec.getLong("activates"));
+            final Instant expires = Instant.ofEpochSecond(keySpec.getLong("expires"));
+            final EncryptionKey key = new EncryptionKey(
                     keySpec.getInteger("id"),
                     Base64.getDecoder().decode(keySpec.getString("secret")),
                     created, activates, expires, siteId);
+
             keyMap.put(key.getId(), key);
             siteKeyMap.computeIfAbsent(siteId, k -> new ArrayList<>()).add(key);
         }
+
         KeyStoreSnapshot snapshot = new KeyStoreSnapshot(keyMap, siteKeyMap);
         return new ParsingResult<>(snapshot, keysSpec.size());
     }

--- a/src/main/java/com/uid2/shared/store/parser/KeysetKeyParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/KeysetKeyParser.java
@@ -3,7 +3,6 @@ package com.uid2.shared.store.parser;
 import com.uid2.shared.Utils;
 import com.uid2.shared.model.KeysetKey;
 import com.uid2.shared.store.KeysetKeyStoreSnapshot;
-import com.uid2.shared.store.reader.RotatingKeysetKeyStore;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -18,23 +17,28 @@ import java.util.List;
 public class KeysetKeyParser implements Parser<KeysetKeyStoreSnapshot> {
     @Override
     public ParsingResult<KeysetKeyStoreSnapshot> deserialize(InputStream inputStream) throws IOException {
-        JsonArray keysSpec = Utils.toJsonArray(inputStream);
+        final JsonArray keysSpec = Utils.toJsonArray(inputStream);
+
         final HashMap<Integer, KeysetKey> keyIdToKeysetKey = new HashMap<>();
         final HashMap<Integer, List<KeysetKey>> keysetIdToKeysetKeyList = new HashMap<>();
+
         for (int i = 0; i < keysSpec.size(); i++) {
             JsonObject keySpec = keysSpec.getJsonObject(i);
-            int keysetId = keySpec.getInteger("keyset_id");
-            Instant created = Instant.ofEpochSecond(keySpec.getLong("created"));
-            Instant activates = Instant.ofEpochSecond(keySpec.getLong("activates"));
-            Instant expires = Instant.ofEpochSecond(keySpec.getLong("expires"));
-            KeysetKey keysetKey = new KeysetKey(
+
+            final int keysetId = keySpec.getInteger("keyset_id");
+            final Instant created = Instant.ofEpochSecond(keySpec.getLong("created"));
+            final Instant activates = Instant.ofEpochSecond(keySpec.getLong("activates"));
+            final Instant expires = Instant.ofEpochSecond(keySpec.getLong("expires"));
+            final KeysetKey keysetKey = new KeysetKey(
                     keySpec.getInteger("id"),
                     Base64.getDecoder().decode(keySpec.getString("secret")),
                     created, activates, expires, keysetId
-                    );
+            );
+
             keyIdToKeysetKey.put(keysetKey.getId(), keysetKey);
             keysetIdToKeysetKeyList.computeIfAbsent(keysetId, k -> new ArrayList<>()).add(keysetKey);
         }
+
         KeysetKeyStoreSnapshot snapshot = new KeysetKeyStoreSnapshot(keyIdToKeysetKey, keysetIdToKeysetKeyList);
         return new ParsingResult<>(snapshot, keysSpec.size());
     }

--- a/src/main/java/com/uid2/shared/store/parser/KeysetKeyParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/KeysetKeyParser.java
@@ -24,11 +24,11 @@ public class KeysetKeyParser implements Parser<KeysetKeyStoreSnapshot> {
 
         for (int i = 0; i < keysSpec.size(); i++) {
             JsonObject keySpec = keysSpec.getJsonObject(i);
-
             final int keysetId = keySpec.getInteger("keyset_id");
             final Instant created = Instant.ofEpochSecond(keySpec.getLong("created"));
             final Instant activates = Instant.ofEpochSecond(keySpec.getLong("activates"));
             final Instant expires = Instant.ofEpochSecond(keySpec.getLong("expires"));
+
             final KeysetKey keysetKey = new KeysetKey(
                     keySpec.getInteger("id"),
                     Base64.getDecoder().decode(keySpec.getString("secret")),

--- a/src/main/java/com/uid2/shared/store/parser/KeysetKeyParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/KeysetKeyParser.java
@@ -17,19 +17,19 @@ import java.util.List;
 public class KeysetKeyParser implements Parser<KeysetKeyStoreSnapshot> {
     @Override
     public ParsingResult<KeysetKeyStoreSnapshot> deserialize(InputStream inputStream) throws IOException {
-        final JsonArray keysSpec = Utils.toJsonArray(inputStream);
+        JsonArray keysSpec = Utils.toJsonArray(inputStream);
 
         final HashMap<Integer, KeysetKey> keyIdToKeysetKey = new HashMap<>();
         final HashMap<Integer, List<KeysetKey>> keysetIdToKeysetKeyList = new HashMap<>();
 
         for (int i = 0; i < keysSpec.size(); i++) {
             JsonObject keySpec = keysSpec.getJsonObject(i);
-            final int keysetId = keySpec.getInteger("keyset_id");
-            final Instant created = Instant.ofEpochSecond(keySpec.getLong("created"));
-            final Instant activates = Instant.ofEpochSecond(keySpec.getLong("activates"));
-            final Instant expires = Instant.ofEpochSecond(keySpec.getLong("expires"));
+            int keysetId = keySpec.getInteger("keyset_id");
+            Instant created = Instant.ofEpochSecond(keySpec.getLong("created"));
+            Instant activates = Instant.ofEpochSecond(keySpec.getLong("activates"));
+            Instant expires = Instant.ofEpochSecond(keySpec.getLong("expires"));
 
-            final KeysetKey keysetKey = new KeysetKey(
+            KeysetKey keysetKey = new KeysetKey(
                     keySpec.getInteger("id"),
                     Base64.getDecoder().decode(keySpec.getString("secret")),
                     created, activates, expires, keysetId

--- a/src/main/java/com/uid2/shared/store/parser/KeysetParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/KeysetParser.java
@@ -39,7 +39,9 @@ public class KeysetParser implements Parser<KeysetSnapshot> {
             final boolean enabled = keysetSpec.getBoolean("enabled");
             final boolean isDefault = keysetSpec.getBoolean("default");
 
-            keysetMap.put(keysetId, new Keyset(keysetId, siteId, name, allowedSites, created, enabled, isDefault));
+            Keyset keyset = new Keyset(keysetId, siteId, name, allowedSites, created, enabled, isDefault);
+
+            keysetMap.put(keysetId, keyset);
         }
 
         return new ParsingResult<>(new KeysetSnapshot(keysetMap), keysetsSpec.size());

--- a/src/main/java/com/uid2/shared/store/parser/KeysetParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/KeysetParser.java
@@ -16,7 +16,9 @@ public class KeysetParser implements Parser<KeysetSnapshot> {
     @Override
     public ParsingResult<KeysetSnapshot> deserialize(InputStream inputStream) throws IOException {
         final JsonArray keysetsSpec = Utils.toJsonArray(inputStream);
+
         final HashMap<Integer, Keyset> keysetMap = new HashMap<>();
+
         for(int i = 0; i < keysetsSpec.size(); i++) {
             final JsonObject keysetSpec = keysetsSpec.getJsonObject(i);
             final Integer keysetId = keysetSpec.getInteger("keyset_id");
@@ -33,12 +35,13 @@ public class KeysetParser implements Parser<KeysetSnapshot> {
                 }
             }
 
-            long created = keysetSpec.getLong("created");
+            final long created = keysetSpec.getLong("created");
             final boolean enabled = keysetSpec.getBoolean("enabled");
             final boolean isDefault = keysetSpec.getBoolean("default");
 
             keysetMap.put(keysetId, new Keyset(keysetId, siteId, name, allowedSites, created, enabled, isDefault));
         }
+
         return new ParsingResult<>(new KeysetSnapshot(keysetMap), keysetsSpec.size());
     }
 }

--- a/src/main/java/com/uid2/shared/store/parser/ServiceLinkParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/ServiceLinkParser.java
@@ -15,10 +15,9 @@ public class ServiceLinkParser implements Parser<Map<String, ServiceLink>> {
 
     @Override
     public ParsingResult<Map<String, ServiceLink>> deserialize(InputStream inputStream) throws IOException {
-        final ServiceLink[] serviceLinks = OBJECT_MAPPER.readValue(inputStream, ServiceLink[].class);
-        final Map<String, ServiceLink> serviceLinkList = Arrays.stream(serviceLinks)
+        ServiceLink[] serviceLinks = OBJECT_MAPPER.readValue(inputStream, ServiceLink[].class);
+        Map<String, ServiceLink> serviceLinkList = Arrays.stream(serviceLinks)
                 .collect(Collectors.toMap(s -> (s.getServiceId() + "_" + s.getLinkId()), s -> s));
         return new ParsingResult<>(serviceLinkList, serviceLinkList.size());
     }
 }
-

--- a/src/main/java/com/uid2/shared/store/parser/ServiceLinkParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/ServiceLinkParser.java
@@ -15,8 +15,8 @@ public class ServiceLinkParser implements Parser<Map<String, ServiceLink>> {
 
     @Override
     public ParsingResult<Map<String, ServiceLink>> deserialize(InputStream inputStream) throws IOException {
-        ServiceLink[] serviceLinks = OBJECT_MAPPER.readValue(inputStream, ServiceLink[].class);
-        Map<String, ServiceLink> serviceLinkList = Arrays.stream(serviceLinks)
+        final ServiceLink[] serviceLinks = OBJECT_MAPPER.readValue(inputStream, ServiceLink[].class);
+        final Map<String, ServiceLink> serviceLinkList = Arrays.stream(serviceLinks)
                 .collect(Collectors.toMap(s -> (s.getServiceId() + "_" + s.getLinkId()), s -> s));
         return new ParsingResult<>(serviceLinkList, serviceLinkList.size());
     }

--- a/src/main/java/com/uid2/shared/store/parser/ServiceLinkParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/ServiceLinkParser.java
@@ -1,6 +1,5 @@
 package com.uid2.shared.store.parser;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.uid2.shared.model.ServiceLink;
@@ -12,17 +11,13 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public class ServiceLinkParser implements Parser<Map<String, ServiceLink>> {
-
     private static final ObjectMapper OBJECT_MAPPER = Mapper.getInstance();
-
-    static {
-        OBJECT_MAPPER.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE);
-    }
 
     @Override
     public ParsingResult<Map<String, ServiceLink>> deserialize(InputStream inputStream) throws IOException {
         ServiceLink[] serviceLinks = OBJECT_MAPPER.readValue(inputStream, ServiceLink[].class);
-        Map<String, ServiceLink> serviceLinkList = Arrays.stream(serviceLinks).collect(Collectors.toMap(s -> (s.getServiceId() + "_" + s.getLinkId()), s -> s));
+        Map<String, ServiceLink> serviceLinkList = Arrays.stream(serviceLinks)
+                .collect(Collectors.toMap(s -> (s.getServiceId() + "_" + s.getLinkId()), s -> s));
         return new ParsingResult<>(serviceLinkList, serviceLinkList.size());
     }
 }

--- a/src/main/java/com/uid2/shared/store/parser/ServiceParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/ServiceParser.java
@@ -11,7 +11,6 @@ import java.io.InputStream;
 import java.util.*;
 
 public class ServiceParser implements Parser<Map<Integer, Service>> {
-
     @Override
     public ParsingResult<Map<Integer, Service>> deserialize(InputStream inputStream) throws IOException {
         JsonArray spec = Utils.toJsonArray(inputStream);

--- a/src/main/java/com/uid2/shared/store/parser/ServiceParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/ServiceParser.java
@@ -14,14 +14,16 @@ public class ServiceParser implements Parser<Map<Integer, Service>> {
     @Override
     public ParsingResult<Map<Integer, Service>> deserialize(InputStream inputStream) throws IOException {
         JsonArray spec = Utils.toJsonArray(inputStream);
+
         final HashMap<Integer, Service> serviceMap = new HashMap<>();
+
         for (int i = 0; i < spec.size(); i++) {
             JsonObject serviceSpec = spec.getJsonObject(i);
             int serviceId = serviceSpec.getInteger("service_id");
             int siteId = serviceSpec.getInteger("site_id");
             String name = serviceSpec.getString("name");
-            JsonArray rolesSpec = serviceSpec.getJsonArray("roles");
 
+            JsonArray rolesSpec = serviceSpec.getJsonArray("roles");
             HashSet<Role> roles = new HashSet<>();
             for (int j = 0; j < rolesSpec.size(); j++) {
                 roles.add(Enum.valueOf(Role.class, rolesSpec.getString(j)));
@@ -31,6 +33,7 @@ public class ServiceParser implements Parser<Map<Integer, Service>> {
 
             serviceMap.put(serviceId, service);
         }
+
         return new ParsingResult<>(serviceMap, serviceMap.size());
     }
 }

--- a/src/main/java/com/uid2/shared/store/parser/SiteParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/SiteParser.java
@@ -15,8 +15,8 @@ public class SiteParser implements Parser<Map<Integer, Site>> {
 
     @Override
     public ParsingResult<Map<Integer, Site>> deserialize(InputStream inputStream) throws IOException {
-        Site[] sites = OBJECT_MAPPER.readValue(inputStream, Site[].class);
-        Map<Integer, Site> sitesMap = Arrays.stream(sites)
+        final Site[] sites = OBJECT_MAPPER.readValue(inputStream, Site[].class);
+        final Map<Integer, Site> sitesMap = Arrays.stream(sites)
                 .collect(Collectors.toMap(Site::getId, s -> s));
         return new ParsingResult<>(sitesMap, sitesMap.size());
     }

--- a/src/main/java/com/uid2/shared/store/parser/SiteParser.java
+++ b/src/main/java/com/uid2/shared/store/parser/SiteParser.java
@@ -15,8 +15,8 @@ public class SiteParser implements Parser<Map<Integer, Site>> {
 
     @Override
     public ParsingResult<Map<Integer, Site>> deserialize(InputStream inputStream) throws IOException {
-        final Site[] sites = OBJECT_MAPPER.readValue(inputStream, Site[].class);
-        final Map<Integer, Site> sitesMap = Arrays.stream(sites)
+        Site[] sites = OBJECT_MAPPER.readValue(inputStream, Site[].class);
+        Map<Integer, Site> sitesMap = Arrays.stream(sites)
                 .collect(Collectors.toMap(Site::getId, s -> s));
         return new ParsingResult<>(sitesMap, sitesMap.size());
     }

--- a/src/main/java/com/uid2/shared/util/CloudEncryptionHelpers.java
+++ b/src/main/java/com/uid2/shared/util/CloudEncryptionHelpers.java
@@ -9,7 +9,6 @@ import com.uid2.shared.encryption.AesGcm;
 import com.uid2.shared.model.CloudEncryptionKey;
 
 import com.uid2.shared.store.reader.RotatingCloudEncryptionKeyProvider;
-import io.vertx.core.json.JsonObject;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 

--- a/src/main/java/com/uid2/shared/util/Mapper.java
+++ b/src/main/java/com/uid2/shared/util/Mapper.java
@@ -3,11 +3,14 @@ package com.uid2.shared.util;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
-public class Mapper {
-    private static final ObjectMapper INSTANCE = new ObjectMapper()
-            .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, true)
-            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+public final class Mapper {
+    private static final ObjectMapper INSTANCE = JsonMapper.builder()
+            .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+            .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .build();
 
     private Mapper() {
     }

--- a/src/test/java/com/uid2/shared/auth/ClientKeyTest.java
+++ b/src/test/java/com/uid2/shared/auth/ClientKeyTest.java
@@ -12,7 +12,7 @@ public class ClientKeyTest {
 
     @Test
     public void verifyDisabledPropIsOptional() throws Exception {
-        String testJson = """
+        final String testJson = """
                     {
                         "key": "test-admin-key",
                         "secret": "",
@@ -34,7 +34,7 @@ public class ClientKeyTest {
 
     @Test
     public void verifyDisabledPropSetTrue() throws Exception {
-        String testJson = """
+        final String testJson = """
                     {
                         "key": "test-admin-key",
                         "secret": "",
@@ -54,7 +54,7 @@ public class ClientKeyTest {
 
     @Test
     public void verifyDisabledPropSetFalse() throws Exception {
-        String testJson = """
+        final String testJson = """
                     {
                         "key": "test-admin-key",
                         "secret": "",

--- a/src/test/java/com/uid2/shared/auth/ClientKeyTest.java
+++ b/src/test/java/com/uid2/shared/auth/ClientKeyTest.java
@@ -12,7 +12,7 @@ public class ClientKeyTest {
 
     @Test
     public void verifyDisabledPropIsOptional() throws Exception {
-        final String testJson = """
+        String testJson = """
                     {
                         "key": "test-admin-key",
                         "secret": "",
@@ -34,7 +34,7 @@ public class ClientKeyTest {
 
     @Test
     public void verifyDisabledPropSetTrue() throws Exception {
-        final String testJson = """
+        String testJson = """
                     {
                         "key": "test-admin-key",
                         "secret": "",
@@ -54,7 +54,7 @@ public class ClientKeyTest {
 
     @Test
     public void verifyDisabledPropSetFalse() throws Exception {
-        final String testJson = """
+        String testJson = """
                     {
                         "key": "test-admin-key",
                         "secret": "",

--- a/src/test/java/com/uid2/shared/auth/ClientKeyTest.java
+++ b/src/test/java/com/uid2/shared/auth/ClientKeyTest.java
@@ -12,19 +12,21 @@ public class ClientKeyTest {
 
     @Test
     public void verifyDisabledPropIsOptional() throws Exception {
-        final String testJson = "{\n" +
-                "    \"key\": \"test-admin-key\",\n" +
-                "    \"secret\": \"\",\n" +
-                "    \"name\": \"admin@uid2.com\",\n" +
-                "    \"contact\": \"admin@uid2.com\",\n" +
-                "    \"created\": 1617149276,\n" +
-                "    \"roles\": [\n" +
-                "        \"MAPPER\",\n" +
-                "        \"GENERATOR\"\n" +
-                "    ],\n" +
-                "    \"site_id\": 3,\n" +
-                "    \"service_id\": 5\n" +
-                "}";
+        final String testJson = """
+                    {
+                        "key": "test-admin-key",
+                        "secret": "",
+                        "name": "admin@uid2.com",
+                        "contact": "admin@uid2.com",
+                        "created": 1617149276,
+                        "roles": [
+                            "MAPPER",
+                            "GENERATOR"
+                        ],
+                        "site_id": 3,
+                        "service_id": 5
+                    }
+                """;
         ClientKey c = OBJECT_MAPPER.readValue(testJson, ClientKey.class);
 
         assertFalse(c.isDisabled());
@@ -32,17 +34,19 @@ public class ClientKeyTest {
 
     @Test
     public void verifyDisabledPropSetTrue() throws Exception {
-        final String testJson = "    {\n" +
-                "        \"key\": \"test-admin-key\",\n" +
-                "        \"secret\": \"\",\n" +
-                "        \"name\": \"admin@uid2.com\",\n" +
-                "        \"contact\": \"admin@uid2.com\",\n" +
-                "        \"created\": 1617149276,\n" +
-                "        \"disabled\": true,\n" +
-                "        \"roles\": [ \"MAPPER\", \"GENERATOR\" ],\n" +
-                "        \"site_id\": 3,\n" +
-                "        \"service_id\": 5\n" +
-                "    }";
+        final String testJson = """
+                    {
+                        "key": "test-admin-key",
+                        "secret": "",
+                        "name": "admin@uid2.com",
+                        "contact": "admin@uid2.com",
+                        "created": 1617149276,
+                        "disabled": true,
+                        "roles": [ "MAPPER", "GENERATOR" ],
+                        "site_id": 3,
+                        "service_id": 5
+                    }
+                """;
         ClientKey c = OBJECT_MAPPER.readValue(testJson, ClientKey.class);
 
         assertTrue(c.isDisabled());
@@ -50,17 +54,19 @@ public class ClientKeyTest {
 
     @Test
     public void verifyDisabledPropSetFalse() throws Exception {
-        final String testJson = "    {\n" +
-                "        \"key\": \"test-admin-key\",\n" +
-                "        \"secret\": \"\",\n" +
-                "        \"name\": \"admin@uid2.com\",\n" +
-                "        \"contact\": \"admin@uid2.com\",\n" +
-                "        \"created\": 1617149276,\n" +
-                "        \"disabled\": false,\n" +
-                "        \"roles\": [ \"MAPPER\", \"GENERATOR\" ],\n" +
-                "        \"site_id\": 3,\n" +
-                "        \"service_id\": 5\n" +
-                "    }";
+        final String testJson = """
+                    {
+                        "key": "test-admin-key",
+                        "secret": "",
+                        "name": "admin@uid2.com",
+                        "contact": "admin@uid2.com",
+                        "created": 1617149276,
+                        "disabled": false,
+                        "roles": [ "MAPPER", "GENERATOR" ],
+                        "site_id": 3,
+                        "service_id": 5
+                    }
+                """;
         ClientKey c = OBJECT_MAPPER.readValue(testJson, ClientKey.class);
 
         assertFalse(c.isDisabled());

--- a/src/test/java/com/uid2/shared/auth/OperatorKeyTest.java
+++ b/src/test/java/com/uid2/shared/auth/OperatorKeyTest.java
@@ -19,13 +19,15 @@ public class OperatorKeyTest {
 
     @Test
     public void verifyDisabledPropIsOptional() throws JsonProcessingException {
-        String testJson = "    {\n" +
-                "        \"name\": \"admin@uid2.com\",\n" +
-                "        \"contact\": \"admin@uid2.com\",\n" +
-                "        \"created\": 1617149276,\n" +
-                "        \"roles\": [ \"OPERATOR\" ],\n" +
-                "        \"site_id\": 3\n" +
-                "    }";
+        String testJson = """
+                    {
+                        "name": "admin@uid2.com",
+                        "contact": "admin@uid2.com",
+                        "created": 1617149276,
+                        "roles": [ "OPERATOR" ],
+                        "site_id": 3
+                    }
+                """;
         OperatorKey o = OBJECT_MAPPER.readValue(testJson, OperatorKey.class);
 
         assertFalse(o.isDisabled());
@@ -33,14 +35,16 @@ public class OperatorKeyTest {
 
     @Test
     public void verifyDisabledPropSetTrue() throws JsonProcessingException {
-        String testJson = "    {\n" +
-                "        \"name\": \"admin@uid2.com\",\n" +
-                "        \"contact\": \"admin@uid2.com\",\n" +
-                "        \"created\": 1617149276,\n" +
-                "        \"disabled\": true,\n" +
-                "        \"roles\": [ \"OPERATOR\" ],\n" +
-                "        \"site_id\": 3\n" +
-                "    }";
+        String testJson = """
+                    {
+                        "name": "admin@uid2.com",
+                        "contact": "admin@uid2.com",
+                        "created": 1617149276,
+                        "disabled": true,
+                        "roles": [ "OPERATOR" ],
+                        "site_id": 3
+                    }
+                """;
         OperatorKey o = OBJECT_MAPPER.readValue(testJson, OperatorKey.class);
 
         assertTrue(o.isDisabled());
@@ -48,14 +52,16 @@ public class OperatorKeyTest {
 
     @Test
     public void verifyDisabledPropSetFalse() throws JsonProcessingException {
-        String testJson = "    {\n" +
-                "        \"name\": \"admin@uid2.com\",\n" +
-                "        \"contact\": \"admin@uid2.com\",\n" +
-                "        \"created\": 1617149276,\n" +
-                "        \"disabled\": false,\n" +
-                "        \"roles\": [ \"OPERATOR\" ],\n" +
-                "        \"site_id\": 3\n" +
-                "    }";
+        String testJson = """
+                    {
+                        "name": "admin@uid2.com",
+                        "contact": "admin@uid2.com",
+                        "created": 1617149276,
+                        "disabled": false,
+                        "roles": [ "OPERATOR" ],
+                        "site_id": 3
+                    }
+                """;
         OperatorKey o = OBJECT_MAPPER.readValue(testJson, OperatorKey.class);
 
         assertFalse(o.isDisabled());
@@ -63,13 +69,15 @@ public class OperatorKeyTest {
 
     @Test
     public void verifySiteIdPropIsOptionalForBackwardsCompatibility() throws JsonProcessingException {
-        String testJson = "    {\n" +
-                "        \"name\": \"admin@uid2.com\",\n" +
-                "        \"contact\": \"admin@uid2.com\",\n" +
-                "        \"created\": 1617149276,\n" +
-                "        \"disabled\": false,\n" +
-                "        \"roles\": [ \"OPERATOR\" ]\n" +
-                "    }";
+        String testJson = """
+                    {
+                        "name": "admin@uid2.com",
+                        "contact": "admin@uid2.com",
+                        "created": 1617149276,
+                        "disabled": false,
+                        "roles": [ "OPERATOR" ]
+                    }
+                """;
         OperatorKey o = OBJECT_MAPPER.readValue(testJson, OperatorKey.class);
 
         assertNull(o.getSiteId());
@@ -77,12 +85,14 @@ public class OperatorKeyTest {
 
     @Test
     public void verifyRolesPropIsOptionalForBackwardsCompatibility() throws JsonProcessingException {
-        String testJson = "    {\n" +
-                "        \"name\": \"admin@uid2.com\",\n" +
-                "        \"contact\": \"admin@uid2.com\",\n" +
-                "        \"created\": 1617149276,\n" +
-                "        \"disabled\": false\n" +
-                "    }";
+        String testJson = """
+                    {
+                        "name": "admin@uid2.com",
+                        "contact": "admin@uid2.com",
+                        "created": 1617149276,
+                        "disabled": false
+                    }
+                """;
         OperatorKey o = OBJECT_MAPPER.readValue(testJson, OperatorKey.class);
 
         assertEquals(Set.of(Role.OPERATOR), o.getRoles());
@@ -90,13 +100,15 @@ public class OperatorKeyTest {
 
     @Test
     public void verifyRolesPropSetOptoutRole() throws JsonProcessingException {
-        String testJson = "    {\n" +
-                "        \"name\": \"admin@uid2.com\",\n" +
-                "        \"contact\": \"admin@uid2.com\",\n" +
-                "        \"created\": 1617149276,\n" +
-                "        \"disabled\": false,\n" +
-                "        \"roles\": [ \"OPTOUT\" ]\n" +
-                "    }";
+        String testJson = """
+                    {
+                        "name": "admin@uid2.com",
+                        "contact": "admin@uid2.com",
+                        "created": 1617149276,
+                        "disabled": false,
+                        "roles": [ "OPTOUT" ]
+                    }
+                """;
         OperatorKey o = OBJECT_MAPPER.readValue(testJson, OperatorKey.class);
 
         // Operator role should be set by default
@@ -105,13 +117,15 @@ public class OperatorKeyTest {
 
     @Test
     public void verifyRolesPropSetOperatorRole() throws JsonProcessingException {
-        String testJson = "    {\n" +
-                "        \"name\": \"admin@uid2.com\",\n" +
-                "        \"contact\": \"admin@uid2.com\",\n" +
-                "        \"created\": 1617149276,\n" +
-                "        \"disabled\": false,\n" +
-                "        \"roles\": [ \"OPERATOR\" ]\n" +
-                "    }";
+        String testJson = """
+                    {
+                        "name": "admin@uid2.com",
+                        "contact": "admin@uid2.com",
+                        "created": 1617149276,
+                        "disabled": false,
+                        "roles": [ "OPERATOR" ]
+                    }
+                """;
         OperatorKey o = OBJECT_MAPPER.readValue(testJson, OperatorKey.class);
 
         assertEquals(Set.of(Role.OPERATOR), o.getRoles());
@@ -119,13 +133,15 @@ public class OperatorKeyTest {
 
     @Test
     public void verifyRolesPropSetOperatorRoleAndOptoutRole() throws JsonProcessingException {
-        String testJson = "    {\n" +
-                "        \"name\": \"admin@uid2.com\",\n" +
-                "        \"contact\": \"admin@uid2.com\",\n" +
-                "        \"created\": 1617149276,\n" +
-                "        \"disabled\": false,\n" +
-                "        \"roles\": [ \"OPERATOR\", \"OPTOUT\" ]\n" +
-                "    }";
+        String testJson = """
+                    {
+                        "name": "admin@uid2.com",
+                        "contact": "admin@uid2.com",
+                        "created": 1617149276,
+                        "disabled": false,
+                        "roles": [ "OPERATOR", "OPTOUT" ]
+                    }
+                """;
         OperatorKey o = OBJECT_MAPPER.readValue(testJson, OperatorKey.class);
 
         assertEquals(Set.of(Role.OPERATOR, Role.OPTOUT), o.getRoles());
@@ -133,13 +149,15 @@ public class OperatorKeyTest {
 
     @Test
     public void verifyRolesPropSetOptoutServiceRole() throws JsonProcessingException {
-        String testJson = "    {\n" +
-                "        \"name\": \"admin@uid2.com\",\n" +
-                "        \"contact\": \"admin@uid2.com\",\n" +
-                "        \"created\": 1617149276,\n" +
-                "        \"disabled\": false,\n" +
-                "        \"roles\": [ \"OPTOUT_SERVICE\" ]\n" +
-                "    }";
+        String testJson = """
+                    {
+                        "name": "admin@uid2.com",
+                        "contact": "admin@uid2.com",
+                        "created": 1617149276,
+                        "disabled": false,
+                        "roles": [ "OPTOUT_SERVICE" ]
+                    }
+                """;
         OperatorKey o = OBJECT_MAPPER.readValue(testJson, OperatorKey.class);
 
         assertEquals(Set.of(Role.OPTOUT_SERVICE), o.getRoles());
@@ -147,19 +165,21 @@ public class OperatorKeyTest {
 
     @Test
     public void verifyRolesPropIsWrittenInAlphabeticalOrder() throws JsonProcessingException {
-        String expectJson = "{" +
-                "\"key_hash\":\"test-keyHash\"," +
-                "\"key_salt\":\"test-keySalt\"," +
-                "\"name\":\"admin@uid2.com\"," +
-                "\"contact\":\"admin@uid2.com\"," +
-                "\"protocol\":\"protocol1\"," +
-                "\"created\":1617149276," +
-                "\"disabled\":false," +
-                "\"site_id\":1," +
-                "\"roles\":[\"OPERATOR\",\"OPTOUT\"]," +
-                "\"operator_type\":\"PRIVATE\"," +
-                "\"key_id\":\"test-keyId\"" +
-                "}";
+        String expectJson = """
+                    {
+                        "key_hash":"test-keyHash",
+                        "key_salt":"test-keySalt",
+                        "name":"admin@uid2.com",
+                        "contact":"admin@uid2.com",
+                        "protocol":"protocol1",
+                        "created":1617149276,
+                        "disabled":false,
+                        "site_id":1,
+                        "roles":["OPERATOR","OPTOUT"],
+                        "operator_type":"PRIVATE",
+                        "key_id":"test-keyId"
+                    }
+                """;
         OperatorKey o = new OperatorKey("test-keyHash", "test-keySalt", "admin@uid2.com", "admin@uid2.com", "protocol1", 1617149276, false, 1, new HashSet<>(Arrays.asList(Role.OPTOUT, Role.OPERATOR)), "test-keyId");
 
         assertEquals(expectJson, OBJECT_MAPPER.writeValueAsString(o));
@@ -167,12 +187,14 @@ public class OperatorKeyTest {
 
     @Test
     public void verifyOperatorTypePropIsOptionalForBackwardsCompatibility() throws JsonProcessingException {
-        String testJson = "    {\n" +
-                "        \"name\": \"admin@uid2.com\",\n" +
-                "        \"contact\": \"admin@uid2.com\",\n" +
-                "        \"created\": 1617149276,\n" +
-                "        \"disabled\": false\n" +
-                "    }";
+        String testJson = """
+                    {
+                        "name": "admin@uid2.com",
+                        "contact": "admin@uid2.com",
+                        "created": 1617149276,
+                        "disabled": false
+                    }
+                """;
         OperatorKey o = OBJECT_MAPPER.readValue(testJson, OperatorKey.class);
 
         assertEquals(OperatorType.PRIVATE, o.getOperatorType());
@@ -180,13 +202,15 @@ public class OperatorKeyTest {
 
     @Test
     public void verifyOperatorTypePropIsPublic() throws JsonProcessingException {
-        String testJson = "    {\n" +
-                "        \"name\": \"admin@uid2.com\",\n" +
-                "        \"contact\": \"admin@uid2.com\",\n" +
-                "        \"created\": 1617149276,\n" +
-                "        \"disabled\": false,\n" +
-                "        \"operator_type\": \"PUBLIC\"\n" +
-                "    }";
+        String testJson = """
+                    {
+                        "name": "admin@uid2.com",
+                        "contact": "admin@uid2.com",
+                        "created": 1617149276,
+                        "disabled": false,
+                        "operator_type": "PUBLIC"
+                    }
+                """;
         OperatorKey o = OBJECT_MAPPER.readValue(testJson, OperatorKey.class);
 
         assertEquals(OperatorType.PUBLIC, o.getOperatorType());
@@ -194,13 +218,15 @@ public class OperatorKeyTest {
 
     @Test
     public void verifyOperatorTypePropIsPrivate() throws JsonProcessingException {
-        String testJson = "    {\n" +
-                "        \"name\": \"admin@uid2.com\",\n" +
-                "        \"contact\": \"admin@uid2.com\",\n" +
-                "        \"created\": 1617149276,\n" +
-                "        \"disabled\": false,\n" +
-                "        \"operator_type\": \"PRIVATE\"\n" +
-                "    }";
+        String testJson = """
+                    {
+                        "name": "admin@uid2.com",
+                        "contact": "admin@uid2.com",
+                        "created": 1617149276,
+                        "disabled": false,
+                        "operator_type": "PRIVATE"
+                    }
+                """;
         OperatorKey o = OBJECT_MAPPER.readValue(testJson, OperatorKey.class);
 
         assertEquals(OperatorType.PRIVATE, o.getOperatorType());

--- a/src/test/java/com/uid2/shared/auth/OperatorKeyTest.java
+++ b/src/test/java/com/uid2/shared/auth/OperatorKeyTest.java
@@ -165,24 +165,9 @@ public class OperatorKeyTest {
 
     @Test
     public void verifyRolesPropIsWrittenInAlphabeticalOrder() throws JsonProcessingException {
-        String expectJson = """
-                    {
-                        "key_hash":"test-keyHash",
-                        "key_salt":"test-keySalt",
-                        "name":"admin@uid2.com",
-                        "contact":"admin@uid2.com",
-                        "protocol":"protocol1",
-                        "created":1617149276,
-                        "disabled":false,
-                        "site_id":1,
-                        "roles":["OPERATOR","OPTOUT"],
-                        "operator_type":"PRIVATE",
-                        "key_id":"test-keyId"
-                    }
-                """;
         OperatorKey o = new OperatorKey("test-keyHash", "test-keySalt", "admin@uid2.com", "admin@uid2.com", "protocol1", 1617149276, false, 1, new HashSet<>(Arrays.asList(Role.OPTOUT, Role.OPERATOR)), "test-keyId");
 
-        assertEquals(expectJson, OBJECT_MAPPER.writeValueAsString(o));
+        assertTrue(OBJECT_MAPPER.writeValueAsString(o).contains("\"roles\":[\"OPERATOR\",\"OPTOUT\"]"));
     }
 
     @Test

--- a/src/test/java/com/uid2/shared/store/EncryptedRotatingSaltProviderTest.java
+++ b/src/test/java/com/uid2/shared/store/EncryptedRotatingSaltProviderTest.java
@@ -7,11 +7,11 @@ import com.uid2.shared.store.reader.RotatingCloudEncryptionKeyProvider;
 import com.uid2.shared.store.scope.EncryptedScope;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -24,8 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 public class EncryptedRotatingSaltProviderTest {
-    private AutoCloseable mocks;
     @Mock
     private ICloudStorage cloudStorage;
 
@@ -35,9 +35,6 @@ public class EncryptedRotatingSaltProviderTest {
 
     @BeforeEach
     public void setup() {
-
-        mocks = MockitoAnnotations.openMocks(this);
-
         byte[] keyBytes = new byte[32];
         new Random().nextBytes(keyBytes);
         String base64Key = Base64.getEncoder().encodeToString(keyBytes);
@@ -47,11 +44,6 @@ public class EncryptedRotatingSaltProviderTest {
         mockKeyMap.put(encryptionKey.getId(), encryptionKey);
         when(keyProvider.getAll()).thenReturn(mockKeyMap);
         when(keyProvider.getKey(1)).thenReturn(mockKeyMap.get(1));
-    }
-
-    @AfterEach
-    public void teardown() throws Exception {
-        mocks.close();
     }
 
     private InputStream getEncryptedStream(String content) {

--- a/src/test/java/com/uid2/shared/store/EncryptedRotatingSaltProviderTest.java
+++ b/src/test/java/com/uid2/shared/store/EncryptedRotatingSaltProviderTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -25,10 +27,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class EncryptedRotatingSaltProviderTest {
     @Mock
     private ICloudStorage cloudStorage;
-
     @Mock
     private RotatingCloudEncryptionKeyProvider keyProvider;
     private CloudEncryptionKey encryptionKey;

--- a/src/test/java/com/uid2/shared/store/RotatingClientSideKeypairStoreTest.java
+++ b/src/test/java/com/uid2/shared/store/RotatingClientSideKeypairStoreTest.java
@@ -60,7 +60,7 @@ public class RotatingClientSideKeypairStoreTest {
         JsonArray content = new JsonArray();
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
-        long count = keypairStore.loadContent(makeMetadata("locationPath"));
+        final long count = keypairStore.loadContent(makeMetadata("locationPath"));
 
         assertEquals(0, count);
         assertNull(keypairStore.getSnapshot().getKeypair("test-subscription-id"));
@@ -79,7 +79,7 @@ public class RotatingClientSideKeypairStoreTest {
         ClientSideKeypair keypair4 = addKeypair(content, "id-4", "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEP5F7PslSFDWcTgasIc1x6183/JqI8WGOqXYxV2n7F6fAdZe8jLVvYtNhub2R+ZfXIDwdDepEZkuNSxfgwM27GA==", "MEECAQAwEwYHKoZIzj0CAQYIKoZIzj0DAQcEJzAlAgEBBCDe6TIHd+Eyoczq1a8xeNGw17OWjeJHZwSLXtuMcqCXZQ==", 3, "email3@email.com", Instant.now(), true, "name 4");
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
-        long count = keypairStore.loadContent(makeMetadata("locationPath"));
+        final long count = keypairStore.loadContent(makeMetadata("locationPath"));
 
         assertEquals(4, count);
         assertEquals(keypair1, keypairStore.getSnapshot().getKeypair("id-1"));

--- a/src/test/java/com/uid2/shared/store/RotatingKeyStoreTest.java
+++ b/src/test/java/com/uid2/shared/store/RotatingKeyStoreTest.java
@@ -78,7 +78,7 @@ public class RotatingKeyStoreTest {
         JsonArray content = new JsonArray();
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
-        long count = keyStore.loadContent(makeMetadata("locationPath"));
+        final long count = keyStore.loadContent(makeMetadata("locationPath"));
 
         assertEquals(0, count);
         assertNull(keyStore.getSnapshot().getMasterKey(Instant.now()));
@@ -96,7 +96,7 @@ public class RotatingKeyStoreTest {
         addKey(content, 103, 203, "key103site203", now);
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
-        long count = keyStore.loadContent(makeMetadata("locationPath"));
+        final long count = keyStore.loadContent(makeMetadata("locationPath"));
 
         assertEquals(3, count);
         checkKeyMatches(keyStore.getSnapshot().getMasterKey(now), 101, -1, "system");
@@ -120,7 +120,7 @@ public class RotatingKeyStoreTest {
         addKey(content, 104, 200, "key104site200", now.minusSeconds(5), now.minusSeconds(1)); // expired
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
-        long count = keyStore.loadContent(makeMetadata("locationPath"));
+        final long count = keyStore.loadContent(makeMetadata("locationPath"));
 
         assertEquals(4, count);
         checkKeyMatches(keyStore.getSnapshot().getKey(101), 101, 200, "key101site200");
@@ -140,7 +140,7 @@ public class RotatingKeyStoreTest {
         addKey(content, 103, Const.Data.MasterKeySiteId, "system3", now.minusSeconds(1));
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
-        long count = keyStore.loadContent(makeMetadata("locationPath"));
+        final long count = keyStore.loadContent(makeMetadata("locationPath"));
 
         assertEquals(3, count);
         checkKeyMatches(keyStore.getSnapshot().getMasterKey(now), 102, -1, "system2");

--- a/src/test/java/com/uid2/shared/store/RotatingKeysetKeyStoreTest.java
+++ b/src/test/java/com/uid2/shared/store/RotatingKeysetKeyStoreTest.java
@@ -62,7 +62,7 @@ public class RotatingKeysetKeyStoreTest {
         JsonArray content = new JsonArray();
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
-        long count = keysetKeyStore.loadContent(makeMetadata("locationPath"));
+        final long count = keysetKeyStore.loadContent(makeMetadata("locationPath"));
 
         assertEquals(0, count);
         assertNull(keysetKeyStore.getSnapshot().getKey(1));
@@ -79,7 +79,7 @@ public class RotatingKeysetKeyStoreTest {
         KeysetKey key3 = addKey(content, 103, 3, "testsecret3", now);
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
-        long count = keysetKeyStore.loadContent(makeMetadata("locationPath"));
+        final long count = keysetKeyStore.loadContent(makeMetadata("locationPath"));
 
         assertEquals(3, count);
         assertEquals(key1, keysetKeyStore.getSnapshot().getKey(101));
@@ -96,7 +96,7 @@ public class RotatingKeysetKeyStoreTest {
         KeysetKey key4 = addKey(content, 104, 200, "key104set200", now.minusSeconds(5), now.minusSeconds(1)); // expired
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
-        long count = keysetKeyStore.loadContent(makeMetadata("locationPath"));
+        final long count = keysetKeyStore.loadContent(makeMetadata("locationPath"));
 
         assertEquals(4, count);
         assertEquals(key1, keysetKeyStore.getSnapshot().getKey(101));

--- a/src/test/java/com/uid2/shared/store/RotatingKeysetKeyStoreTest.java
+++ b/src/test/java/com/uid2/shared/store/RotatingKeysetKeyStoreTest.java
@@ -7,33 +7,26 @@ import com.uid2.shared.store.scope.GlobalScope;
 import static com.uid2.shared.TestUtilites.makeInputStream;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 public class RotatingKeysetKeyStoreTest {
-    private AutoCloseable mocks;
     @Mock
     ICloudStorage cloudStorage;
     private RotatingKeysetKeyStore keysetKeyStore;
 
     @BeforeEach
     public void setup() {
-        mocks = MockitoAnnotations.openMocks(this);
         keysetKeyStore = new RotatingKeysetKeyStore(cloudStorage, new GlobalScope(new CloudPath("metadata")));
-    }
-
-    @AfterEach
-    public void teardown() throws Exception {
-        mocks.close();
     }
 
     private JsonObject makeMetadata(String location) {
@@ -68,7 +61,9 @@ public class RotatingKeysetKeyStoreTest {
     public void loadContentEmptyArray() throws Exception {
         JsonArray content = new JsonArray();
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
-        final long count = keysetKeyStore.loadContent(makeMetadata("locationPath"));
+
+        long count = keysetKeyStore.loadContent(makeMetadata("locationPath"));
+
         assertEquals(0, count);
         assertNull(keysetKeyStore.getSnapshot().getKey(1));
         assertNull(keysetKeyStore.getSnapshot().getActiveKey(1, Instant.now()));
@@ -83,11 +78,13 @@ public class RotatingKeysetKeyStoreTest {
         KeysetKey key2 = addKey(content, 102, 2, "testsecret2", now);
         KeysetKey key3 = addKey(content, 103, 3, "testsecret3", now);
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
-        final long conunt = keysetKeyStore.loadContent(makeMetadata("locationPath"));
-        assertEquals(3, conunt);
-        assertTrue(keysetKeyStore.getSnapshot().getKey(101).equals(key1));
-        assertTrue(keysetKeyStore.getSnapshot().getKey(102).equals(key2));
-        assertTrue(keysetKeyStore.getSnapshot().getKey(103).equals(key3));
+
+        long count = keysetKeyStore.loadContent(makeMetadata("locationPath"));
+
+        assertEquals(3, count);
+        assertEquals(key1, keysetKeyStore.getSnapshot().getKey(101));
+        assertEquals(key2, keysetKeyStore.getSnapshot().getKey(102));
+        assertEquals(key3, keysetKeyStore.getSnapshot().getKey(103));
     }
     @Test
     public void loadContentMultipleFromSingleKeyset() throws Exception {
@@ -98,13 +95,16 @@ public class RotatingKeysetKeyStoreTest {
         KeysetKey key3 = addKey(content, 103, 200, "key103set200", now.minusSeconds(10), now.plusSeconds(20));
         KeysetKey key4 = addKey(content, 104, 200, "key104set200", now.minusSeconds(5), now.minusSeconds(1)); // expired
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
-        final long count = keysetKeyStore.loadContent(makeMetadata("locationPath"));
+
+        long count = keysetKeyStore.loadContent(makeMetadata("locationPath"));
+
         assertEquals(4, count);
-        assertEquals(keysetKeyStore.getSnapshot().getKey(101), key1);
-        assertEquals(keysetKeyStore.getSnapshot().getKey(102), key2);
-        assertEquals(keysetKeyStore.getSnapshot().getKey(103), key3);
-        assertEquals(keysetKeyStore.getSnapshot().getKey(104), key4);
-        //Check active key is correct
+        assertEquals(key1, keysetKeyStore.getSnapshot().getKey(101));
+        assertEquals(key2, keysetKeyStore.getSnapshot().getKey(102));
+        assertEquals(key3, keysetKeyStore.getSnapshot().getKey(103));
+        assertEquals(key4, keysetKeyStore.getSnapshot().getKey(104));
+
+        // Check active key is correct
         assertEquals(keysetKeyStore.getSnapshot().getActiveKey(200, now), key3);
         assertEquals(keysetKeyStore.getSnapshot().getActiveKey(200, keysetKeyStore.getSnapshot().getKey(103).getActivates()), key3);
     }

--- a/src/test/java/com/uid2/shared/store/RotatingSaltProviderTest.java
+++ b/src/test/java/com/uid2/shared/store/RotatingSaltProviderTest.java
@@ -3,11 +3,10 @@ package com.uid2.shared.store;
 import com.uid2.shared.cloud.ICloudStorage;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
@@ -18,20 +17,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 public class RotatingSaltProviderTest {
-    private AutoCloseable mocks;
     @Mock
     private ICloudStorage cloudStorage;
-
-    @BeforeEach
-    public void setup() {
-        mocks = MockitoAnnotations.openMocks(this);
-    }
-
-    @AfterEach
-    public void teardown() throws Exception {
-        mocks.close();
-    }
 
     @Test
     public void loadSaltSingleVersion() throws Exception {
@@ -64,13 +53,13 @@ public class RotatingSaltProviderTest {
         final String effectiveTimeString = String.valueOf(generatedTime.getEpochSecond() * 1000L);
         final String salts =
                 "1000000," + effectiveTimeString + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=\n" +
-                "1000001," + effectiveTimeString + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=\n" +
-                "1000002," + effectiveTimeString + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=\n" +
-                "1000003," + effectiveTimeString + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=\n" +
-                "1000004," + effectiveTimeString + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=\n" +
-                "1000005," + effectiveTimeString + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=\n" +
-                "1000006," + effectiveTimeString + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=\n" +
-                "1000007," + effectiveTimeString + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=";
+                        "1000001," + effectiveTimeString + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=\n" +
+                        "1000002," + effectiveTimeString + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=\n" +
+                        "1000003," + effectiveTimeString + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=\n" +
+                        "1000004," + effectiveTimeString + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=\n" +
+                        "1000005," + effectiveTimeString + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=\n" +
+                        "1000006," + effectiveTimeString + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=\n" +
+                        "1000007," + effectiveTimeString + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=";
 
         when(cloudStorage.download("metadata"))
                 .thenReturn(new ByteArrayInputStream(metadataJson.toString().getBytes(StandardCharsets.US_ASCII)));
@@ -130,25 +119,25 @@ public class RotatingSaltProviderTest {
         final String effectiveTimeStringV1 = String.valueOf(generatedTimeV1.getEpochSecond() * 1000L);
         final String saltsV1 =
                 "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=\n" +
-                "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=\n" +
-                "1000002," + effectiveTimeStringV1 + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=\n" +
-                "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=\n" +
-                "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=\n" +
-                "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=\n" +
-                "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=\n" +
-                "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=";
+                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=\n" +
+                        "1000002," + effectiveTimeStringV1 + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=\n" +
+                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=\n" +
+                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=\n" +
+                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=\n" +
+                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=\n" +
+                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=";
 
         // update key 1000002
         final String effectiveTimeStringV2 = String.valueOf(generatedTimeV2.getEpochSecond() * 1000L);
         final String saltsV2 =
                 "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=\n" +
-                "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=\n" +
-                "1000002," + effectiveTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=\n" +
-                "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=\n" +
-                "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=\n" +
-                "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=\n" +
-                "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=\n" +
-                "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=";
+                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=\n" +
+                        "1000002," + effectiveTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=\n" +
+                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=\n" +
+                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=\n" +
+                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=\n" +
+                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=\n" +
+                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=";
 
         when(cloudStorage.download("metadata"))
                 .thenReturn(new ByteArrayInputStream(metadataJson.toString().getBytes(StandardCharsets.US_ASCII)));

--- a/src/test/java/com/uid2/shared/store/RotatingServiceLinkStoreTest.java
+++ b/src/test/java/com/uid2/shared/store/RotatingServiceLinkStoreTest.java
@@ -7,15 +7,14 @@ import com.uid2.shared.store.reader.RotatingServiceLinkStore;
 import com.uid2.shared.store.scope.GlobalScope;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -23,22 +22,15 @@ import static com.uid2.shared.TestUtilites.makeInputStream;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 public class RotatingServiceLinkStoreTest {
-
-    private AutoCloseable mocks;
     @Mock
     ICloudStorage cloudStorage;
     private RotatingServiceLinkStore serviceLinkStore;
 
     @BeforeEach
     public void setup() {
-        mocks = MockitoAnnotations.openMocks(this);
         serviceLinkStore = new RotatingServiceLinkStore(cloudStorage, new GlobalScope(new CloudPath("metadata")));
-    }
-
-    @AfterEach
-    public void teardown() throws Exception {
-        mocks.close();
     }
 
     private JsonObject makeMetadata(String location) {
@@ -60,7 +52,9 @@ public class RotatingServiceLinkStoreTest {
     public void loadContent_emptyArray_loadsZeroServiceLinks() throws Exception {
         JsonArray content = new JsonArray();
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
-        final long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));
+
+        long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));
+
         assertEquals(0, count);
         assertEquals(0, serviceLinkStore.getAllServiceLinks().size());
     }
@@ -74,7 +68,8 @@ public class RotatingServiceLinkStoreTest {
         ServiceLink l4 = addServiceLink(content, "jkl1011", 3, 124, "test2", null);
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
-        final long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));
+        long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));
+
         assertEquals(4, count);
         assertTrue(serviceLinkStore.getAllServiceLinks().containsAll(Arrays.asList(l1, l2, l3, l4)));
     }
@@ -88,7 +83,7 @@ public class RotatingServiceLinkStoreTest {
 
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
-        final long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));
+        long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));
 
         List<ServiceLink> expected = List.of(l1, l2, l3);
         List<ServiceLink> actual = List.of(

--- a/src/test/java/com/uid2/shared/store/RotatingServiceLinkStoreTest.java
+++ b/src/test/java/com/uid2/shared/store/RotatingServiceLinkStoreTest.java
@@ -53,7 +53,7 @@ public class RotatingServiceLinkStoreTest {
         JsonArray content = new JsonArray();
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
-        long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));
+        final long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));
 
         assertEquals(0, count);
         assertEquals(0, serviceLinkStore.getAllServiceLinks().size());
@@ -68,7 +68,7 @@ public class RotatingServiceLinkStoreTest {
         ServiceLink l4 = addServiceLink(content, "jkl1011", 3, 124, "test2", null);
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
-        long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));
+        final long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));
 
         assertEquals(4, count);
         assertTrue(serviceLinkStore.getAllServiceLinks().containsAll(Arrays.asList(l1, l2, l3, l4)));
@@ -83,7 +83,7 @@ public class RotatingServiceLinkStoreTest {
 
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
-        long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));
+        final long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));
 
         List<ServiceLink> expected = List.of(l1, l2, l3);
         List<ServiceLink> actual = List.of(
@@ -103,6 +103,7 @@ public class RotatingServiceLinkStoreTest {
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
         final long count = serviceLinkStore.loadContent(makeMetadata("locationPath"));
+
         assertEquals(1, count);
         assertEquals(serviceLinkStore.getServiceLink(3, "jkl1011"), new ServiceLink("jkl1011", 3, 124, "Test Service", Set.of()));
     }

--- a/src/test/java/com/uid2/shared/store/RotatingServiceStoreTest.java
+++ b/src/test/java/com/uid2/shared/store/RotatingServiceStoreTest.java
@@ -7,11 +7,11 @@ import com.uid2.shared.store.reader.RotatingServiceStore;
 import com.uid2.shared.store.scope.GlobalScope;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -21,22 +21,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 public class RotatingServiceStoreTest {
-
-    private AutoCloseable mocks;
     @Mock
     ICloudStorage cloudStorage;
     private RotatingServiceStore serviceStore;
 
     @BeforeEach
     public void setup() {
-        mocks = MockitoAnnotations.openMocks(this);
         serviceStore = new RotatingServiceStore(cloudStorage, new GlobalScope(new CloudPath("metadata")));
-    }
-
-    @AfterEach
-    public void teardown() throws Exception {
-        mocks.close();
     }
 
     private JsonObject makeMetadata(String location) {

--- a/src/test/java/com/uid2/shared/store/RotatingSiteStoreTest.java
+++ b/src/test/java/com/uid2/shared/store/RotatingSiteStoreTest.java
@@ -59,7 +59,7 @@ public class RotatingSiteStoreTest {
         JsonArray content = new JsonArray();
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
-        long count = siteStore.loadContent(makeMetadata("locationPath"));
+        final long count = siteStore.loadContent(makeMetadata("locationPath"));
 
         assertEquals(0, count);
         assertEquals(0, siteStore.getAllSites().size());
@@ -74,7 +74,8 @@ public class RotatingSiteStoreTest {
         Site s4 = addSite(content, 126, "test-4", "test-4-desc", false, false, Instant.now().getEpochSecond(), new HashSet<>(List.of("testdomain1.com", "testdomain2.net")), new HashSet<>(List.of("testAppName1", "testAppName2")));
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
-        long count = siteStore.loadContent(makeMetadata("locationPath"));
+        final long count = siteStore.loadContent(makeMetadata("locationPath"));
+
         assertEquals(4, count);
 
         assertEquals(s1, siteStore.getSite(123));

--- a/src/test/java/com/uid2/shared/store/RotatingSiteStoreTest.java
+++ b/src/test/java/com/uid2/shared/store/RotatingSiteStoreTest.java
@@ -11,7 +11,9 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
 import java.util.HashSet;
@@ -23,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 public class RotatingSiteStoreTest {
     private static final ObjectMapper OBJECT_MAPPER = Mapper.getInstance();
 

--- a/src/test/java/com/uid2/shared/store/RotatingSiteStoreTest.java
+++ b/src/test/java/com/uid2/shared/store/RotatingSiteStoreTest.java
@@ -9,11 +9,9 @@ import com.uid2.shared.store.scope.GlobalScope;
 import com.uid2.shared.util.Mapper;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import java.time.Instant;
 import java.util.HashSet;
@@ -28,20 +26,13 @@ import static org.mockito.Mockito.when;
 public class RotatingSiteStoreTest {
     private static final ObjectMapper OBJECT_MAPPER = Mapper.getInstance();
 
-    private AutoCloseable mocks;
     @Mock
     private ICloudStorage cloudStorage;
     private RotatingSiteStore siteStore;
 
     @BeforeEach
     public void setup() {
-        mocks = MockitoAnnotations.openMocks(this);
         siteStore = new RotatingSiteStore(cloudStorage, new GlobalScope(new CloudPath("metadata")));
-    }
-
-    @AfterEach
-    public void teardown() throws Exception {
-        mocks.close();
     }
 
     private JsonObject makeMetadata(String location) {

--- a/src/test/java/com/uid2/shared/store/RotatingSiteStoreTest.java
+++ b/src/test/java/com/uid2/shared/store/RotatingSiteStoreTest.java
@@ -27,9 +27,10 @@ import static org.mockito.Mockito.when;
 
 public class RotatingSiteStoreTest {
     private static final ObjectMapper OBJECT_MAPPER = Mapper.getInstance();
+
     private AutoCloseable mocks;
     @Mock
-    ICloudStorage cloudStorage;
+    private ICloudStorage cloudStorage;
     private RotatingSiteStore siteStore;
 
     @BeforeEach
@@ -52,7 +53,6 @@ public class RotatingSiteStoreTest {
     }
 
     private Site addSite(JsonArray content, int siteId, String name, String description, boolean enabled, boolean visible, long created, Set<String> domains, Set<String> appNames) {
-
         Site s = new Site(siteId, name, description, enabled, new HashSet<>(), domains, appNames, visible, created);
         JsonNode jsonNode = OBJECT_MAPPER.convertValue(s, JsonNode.class);
         content.add(jsonNode);
@@ -64,7 +64,9 @@ public class RotatingSiteStoreTest {
     public void loadContentEmptyArray() throws Exception {
         JsonArray content = new JsonArray();
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
-        final long count = siteStore.loadContent(makeMetadata("locationPath"));
+
+        long count = siteStore.loadContent(makeMetadata("locationPath"));
+
         assertEquals(0, count);
         assertEquals(0, siteStore.getAllSites().size());
     }
@@ -78,7 +80,7 @@ public class RotatingSiteStoreTest {
         Site s4 = addSite(content, 126, "test-4", "test-4-desc", false, false, Instant.now().getEpochSecond(), new HashSet<>(List.of("testdomain1.com", "testdomain2.net")), new HashSet<>(List.of("testAppName1", "testAppName2")));
         when(cloudStorage.download("locationPath")).thenReturn(makeInputStream(content));
 
-        final long count = siteStore.loadContent(makeMetadata("locationPath"));
+        long count = siteStore.loadContent(makeMetadata("locationPath"));
         assertEquals(4, count);
 
         assertEquals(s1, siteStore.getSite(123));

--- a/src/test/java/com/uid2/shared/store/parser/CloudEncryptionKeyParserTest.java
+++ b/src/test/java/com/uid2/shared/store/parser/CloudEncryptionKeyParserTest.java
@@ -1,6 +1,7 @@
 package com.uid2.shared.store.parser;
 
 import com.uid2.shared.model.CloudEncryptionKey;
+import com.uid2.shared.util.Mapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -14,24 +15,43 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class CloudEncryptionKeyParserTest {
+public class CloudEncryptionKeyParserTest {
+    private static final ObjectMapper OBJECT_MAPPER = Mapper.getInstance();
 
     private CloudEncryptionKeyParser parser;
 
     @BeforeEach
-    void setUp() {
+    public void setup() {
         parser = new CloudEncryptionKeyParser();
     }
 
     @Test
     void testDeserialize() throws IOException {
-        String json = "[{" +
-                "\"id\": 1, \"site_id\": 123, \"activates\": 1687635529, \"created\": 1687808329, \"secret\": \"S3keySecretByteHere1\"" +
-                "},{" +
-                "\"id\": 2, \"site_id\": 123, \"activates\": 1687808429, \"created\": 1687808329, \"secret\": \"S3keySecretByteHere2\"" +
-                "},{" +
-                "\"id\": 3, \"site_id\": 456, \"activates\": 1687635529, \"created\": 1687808329, \"secret\": \"S3keySecretByteHere3\"" +
-                "}]";
+        String json = """
+                [
+                    {
+                        "id": 1,
+                        "site_id": 123,
+                        "activates": 1687635529,
+                        "created": 1687808329,
+                        "secret": "S3keySecretByteHere1"
+                    },
+                    {
+                        "id": 2,
+                        "site_id": 123,
+                        "activates": 1687808429,
+                        "created": 1687808329,
+                        "secret": "S3keySecretByteHere2"
+                    },
+                    {
+                        "id": 3,
+                        "site_id": 456,
+                        "activates": 1687635529,
+                        "created": 1687808329,
+                        "secret": "S3keySecretByteHere3"
+                    }
+                ]
+            """;
         InputStream inputStream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
 
         ParsingResult<Map<Integer, CloudEncryptionKey>> result = parser.deserialize(inputStream);
@@ -78,7 +98,16 @@ class CloudEncryptionKeyParserTest {
 
     @Test
     void testDeserializeInvalidJson() {
-        String json = "[{\"id\": 1, \"site_id\": 123, \"activates\": 1687635529, \"created\": 1687808329, \"secret\": \"S3keySecretByteHere1\",]";
+        String json = """
+                [
+                    {
+                        "id": 1,
+                        "site_id": 123,
+                        "activates": 1687635529,
+                        "created": 1687808329,
+                        "secret": "S3keySecretByteHere1",
+                ]
+            """;
         InputStream inputStream = new ByteArrayInputStream(json.getBytes());
 
         assertThrows(IOException.class, () -> parser.deserialize(inputStream));
@@ -87,8 +116,7 @@ class CloudEncryptionKeyParserTest {
     @Test
     void testCloudEncryptionKeySerialization() throws Exception {
         CloudEncryptionKey cloudEncryptionKey = new CloudEncryptionKey(1, 999, 1718689091L, 1718689091L, "64bNHMpU/mjaywjOpVacFOvEIFZmbYYUsNVNVu1jJZs=");
-        ObjectMapper mapper = new ObjectMapper();
-        String jsonString = mapper.writeValueAsString(cloudEncryptionKey);
+        String jsonString = OBJECT_MAPPER.writeValueAsString(cloudEncryptionKey);
 
         String expectedJson = "{\"id\":1,\"siteId\":999,\"activates\":1718689091,\"created\":1718689091,\"secret\":\"64bNHMpU/mjaywjOpVacFOvEIFZmbYYUsNVNVu1jJZs=\"}";
         assertEquals(expectedJson, jsonString);
@@ -96,29 +124,31 @@ class CloudEncryptionKeyParserTest {
 
     @Test
     void testDeserializeEndpointResults() throws IOException {
-        String json = "[\n" +
-                "        {\n" +
-                "            \"id\": 1,\n" +
-                "            \"siteId\": 999,\n" +
-                "            \"activates\": 1720641670,\n" +
-                "            \"created\": 1720641670,\n" +
-                "            \"secret\": \"mydrCudb2PZOm01Qn0SpthltmexHUAA11Hy1m+uxjVw=\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "            \"id\": 2,\n" +
-                "            \"siteId\": 999,\n" +
-                "            \"activates\": 1720728070,\n" +
-                "            \"created\": 1720641670,\n" +
-                "            \"secret\": \"FtdslrFSsvVXOuhOWGwEI+0QTkCvM8SGZAP3k2u3PgY=\"\n" +
-                "        },\n" +
-                "        {\n" +
-                "            \"id\": 3,\n" +
-                "            \"siteId\": 999,\n" +
-                "            \"activates\": 1720814470,\n" +
-                "            \"created\": 1720641670,\n" +
-                "            \"secret\": \"/7zO6QbKrhZKIV36G+cU9UR4hZUVg5bD+KjbczICjHw=\"\n" +
-                "        }\n" +
-                "    ]";
+        String json = """
+                [
+                    {
+                        "id": 1,
+                        "siteId": 999,
+                        "activates": 1720641670,
+                        "created": 1720641670,
+                        "secret": "mydrCudb2PZOm01Qn0SpthltmexHUAA11Hy1m+uxjVw="
+                    },
+                    {
+                        "id": 2,
+                        "siteId": 999,
+                        "activates": 1720728070,
+                        "created": 1720641670,
+                        "secret": "FtdslrFSsvVXOuhOWGwEI+0QTkCvM8SGZAP3k2u3PgY="
+                    },
+                    {
+                        "id": 3,
+                        "siteId": 999,
+                        "activates": 1720814470,
+                        "created": 1720641670,
+                        "secret": "/7zO6QbKrhZKIV36G+cU9UR4hZUVg5bD+KjbczICjHw="
+                    }
+                ]
+            """;
         InputStream inputStream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8));
 
         ParsingResult<Map<Integer, CloudEncryptionKey>> result = parser.deserialize(inputStream);

--- a/src/test/java/com/uid2/shared/util/MapperTest.java
+++ b/src/test/java/com/uid2/shared/util/MapperTest.java
@@ -12,11 +12,11 @@ public class MapperTest {
     @Test
     public void readValue_whenEnumIsCaseInsensitive() throws Exception {
         String json = """
-            {
-                "omTestString": "test",
-                "omTestType": "tYpE_oNe"
-            }
-        """;
+                {
+                    "omTestString": "test",
+                    "omTestType": "tYpE_oNe"
+                }
+            """;
         OMTestObject omTestObject = OBJECT_MAPPER.readValue(json, OMTestObject.class);
 
         assertEquals(OMTestType.TYPE_ONE, omTestObject.omTestType());
@@ -25,14 +25,28 @@ public class MapperTest {
     @Test
     public void readValue_whenUnknownProperties() throws Exception {
         String json = """
-            {
-                "omTestString": "test",
-                "omTestType": "TYPE_ONE",
-                "unknownType": "abcdef"
-            }
-        """;
+                {
+                    "omTestString": "test",
+                    "omTestType": "TYPE_ONE",
+                    "unknownType": "abcdef"
+                }
+            """;
         OMTestObject omTestObject = OBJECT_MAPPER.readValue(json, OMTestObject.class);
         OMTestObject expected = new OMTestObject("test", OMTestType.TYPE_ONE);
+
+        assertEquals(expected, omTestObject);
+    }
+
+    @Test
+    public void readValue_whenUnknownEnum() throws Exception {
+        String json = """
+                {
+                    "omTestString": "test",
+                    "omTestType": "TYPE_THREE"
+                }
+            """;
+        OMTestObject omTestObject = OBJECT_MAPPER.readValue(json, OMTestObject.class);
+        OMTestObject expected = new OMTestObject("test", OMTestType.UNKNOWN);
 
         assertEquals(expected, omTestObject);
     }
@@ -41,7 +55,7 @@ public class MapperTest {
     public void readValue_whenMissingProperties() throws Exception {
         String json = "{}";
         OMTestObject omTestObject = OBJECT_MAPPER.readValue(json, OMTestObject.class);
-        OMTestObject expected = new OMTestObject(null, OMTestType.UNKNOWN);
+        OMTestObject expected = new OMTestObject(null, null);
 
         assertEquals(expected, omTestObject);
     }

--- a/src/test/java/com/uid2/shared/util/MapperTest.java
+++ b/src/test/java/com/uid2/shared/util/MapperTest.java
@@ -1,11 +1,8 @@
 package com.uid2.shared.util;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
-
-import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -14,58 +11,48 @@ public class MapperTest {
 
     @Test
     public void readValue_whenEnumIsCaseInsensitive() throws Exception {
-        String json = "{\"omf_type\":\"tYpE_oNe\"}";
-        OMFObject omfObject = OBJECT_MAPPER.readValue(json, OMFObject.class);
+        String json = """
+            {
+                "omTestString": "test",
+                "omTestType": "tYpE_oNe"
+            }
+        """;
+        OMTestObject omTestObject = OBJECT_MAPPER.readValue(json, OMTestObject.class);
 
-        assertEquals(OMFType.TYPE_ONE, omfObject.getOmfType());
+        assertEquals(OMTestType.TYPE_ONE, omTestObject.omTestType());
     }
 
     @Test
     public void readValue_whenUnknownProperties() throws Exception {
-        String json = "{\"omf_type\":\"TYPE_ONE\", \"unknown_type\":\"abcdef\"}";
-        OMFObject omfObject = OBJECT_MAPPER.readValue(json, OMFObject.class);
-        OMFObject expected = new OMFObject(OMFType.TYPE_ONE);
+        String json = """
+            {
+                "omTestString": "test",
+                "omTestType": "TYPE_ONE",
+                "unknownType": "abcdef"
+            }
+        """;
+        OMTestObject omTestObject = OBJECT_MAPPER.readValue(json, OMTestObject.class);
+        OMTestObject expected = new OMTestObject("test", OMTestType.TYPE_ONE);
 
-        assertEquals(expected, omfObject);
+        assertEquals(expected, omTestObject);
     }
 
     @Test
     public void readValue_whenMissingProperties() throws Exception {
         String json = "{}";
-        OMFObject omfObject = OBJECT_MAPPER.readValue(json, OMFObject.class);
-        OMFObject expected = new OMFObject(null);
+        OMTestObject omTestObject = OBJECT_MAPPER.readValue(json, OMTestObject.class);
+        OMTestObject expected = new OMTestObject(null, OMTestType.UNKNOWN);
 
-        assertEquals(expected, omfObject);
+        assertEquals(expected, omTestObject);
     }
 
-    private enum OMFType {
+    private enum OMTestType {
         TYPE_ONE,
-        TYPE_TWO
+        TYPE_TWO,
+        @JsonEnumDefaultValue
+        UNKNOWN
     }
 
-    private static class OMFObject {
-        private final OMFType omfType;
-
-        @JsonCreator
-        public OMFObject(@JsonProperty("omf_type") OMFType omfType) {
-            this.omfType = omfType;
-        }
-
-        public OMFType getOmfType() {
-            return omfType;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            OMFObject omfObject = (OMFObject) o;
-            return omfType == omfObject.omfType;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(omfType);
-        }
+    private record OMTestObject(String omTestString, OMTestType omTestType) {
     }
 }


### PR DESCRIPTION
* Consolidated all `ObjectMapper` to `Mapper` singleton and replaced single instantiation of `ObjectMapper` with `Mapper.getInstance()` 
  * All usage of `ObjectMapper`s in `uid2-shared` is for internal data structures, and the consolidated configs allow for less strict JSON deserialization
* Changed `AutoCloseable` mocks to `@ExtendWith(MockitoExtension.class)`
  * Cleans up manual mock setup/teardown
* Changed JSON strings in unit tests to string blocks for readability
* Other minor code enhancements for logging and if-conditions