### PR TITLE
sch-UID2-4661 detailed error message when http request to core is not a success

### DIFF
--- a/src/main/java/com/uid2/shared/attest/UidCoreClient.java
+++ b/src/main/java/com/uid2/shared/attest/UidCoreClient.java
@@ -106,9 +106,9 @@ public class UidCoreClient implements IUidCoreClient, DownloadCloudStorage {
 
         HttpResponse<String> httpResponse;
         httpResponse = sendHttpRequest(path, attestationToken);
-//        if (httpResponse.statusCode() != 200) {
-//            throw new IOException(String.format("Non-success response from core on request to %s. Status code: %d, Response: %s", path, httpResponse.statusCode(), httpResponse.body()));
-//        }
+        if (httpResponse.statusCode() != 200) {
+            throw new CloudStorageException(String.format("Non-success response from core on request to %s. Status code: %d, Response: %s", path, httpResponse.statusCode(), httpResponse.body()));
+        }
         return Utils.convertHttpResponseToInputStream(httpResponse);
     }
 

--- a/src/main/java/com/uid2/shared/attest/UidCoreClient.java
+++ b/src/main/java/com/uid2/shared/attest/UidCoreClient.java
@@ -107,7 +107,7 @@ public class UidCoreClient implements IUidCoreClient, DownloadCloudStorage {
         HttpResponse<String> httpResponse;
         httpResponse = sendHttpRequest(path, attestationToken);
         if (httpResponse.statusCode() != 200) {
-            LOGGER.error("Non-success response from core on request to {}. Status code: {}, Response: {}", path, httpResponse.statusCode(), httpResponse.body());
+            LOGGER.warn("Non-success response from core on request_url={} status_code={} response={}", path, httpResponse.statusCode(), httpResponse.body());
         }
         return Utils.convertHttpResponseToInputStream(httpResponse);
     }

--- a/src/main/java/com/uid2/shared/attest/UidCoreClient.java
+++ b/src/main/java/com/uid2/shared/attest/UidCoreClient.java
@@ -107,7 +107,7 @@ public class UidCoreClient implements IUidCoreClient, DownloadCloudStorage {
         HttpResponse<String> httpResponse;
         httpResponse = sendHttpRequest(path, attestationToken);
         if (httpResponse.statusCode() != 200) {
-            throw new CloudStorageException(String.format("Non-success response from core on request %s. Status code %d. Response %s", path, httpResponse.statusCode(), httpResponse.body()));
+            throw new CloudStorageException(String.format("Non-success response from core on request to %s. Status code: %d. Response: %s", path, httpResponse.statusCode(), httpResponse.body()));
         }
         return Utils.convertHttpResponseToInputStream(httpResponse);
     }

--- a/src/main/java/com/uid2/shared/attest/UidCoreClient.java
+++ b/src/main/java/com/uid2/shared/attest/UidCoreClient.java
@@ -97,7 +97,7 @@ public class UidCoreClient implements IUidCoreClient, DownloadCloudStorage {
         return (proxy == null ? new URL(path).openConnection() : new URL(path).openConnection(proxy)).getInputStream();
     }
 
-    private InputStream getWithAttest(String path) throws IOException, AttestationResponseHandlerException, CloudStorageException {
+    private InputStream getWithAttest(String path) throws IOException, AttestationResponseHandlerException {
         if (!attestationResponseHandler.attested()) {
             attestationResponseHandler.attest();
         }
@@ -107,7 +107,7 @@ public class UidCoreClient implements IUidCoreClient, DownloadCloudStorage {
         HttpResponse<String> httpResponse;
         httpResponse = sendHttpRequest(path, attestationToken);
         if (httpResponse.statusCode() != 200) {
-            throw new CloudStorageException(String.format("Non-success response from core on request to %s. Status code: %d, Response: %s", path, httpResponse.statusCode(), httpResponse.body()));
+            LOGGER.error("Non-success response from core on request to {}. Status code: {}, Response: {}", path, httpResponse.statusCode(), httpResponse.body());
         }
         return Utils.convertHttpResponseToInputStream(httpResponse);
     }

--- a/src/main/java/com/uid2/shared/attest/UidCoreClient.java
+++ b/src/main/java/com/uid2/shared/attest/UidCoreClient.java
@@ -97,7 +97,7 @@ public class UidCoreClient implements IUidCoreClient, DownloadCloudStorage {
         return (proxy == null ? new URL(path).openConnection() : new URL(path).openConnection(proxy)).getInputStream();
     }
 
-    private InputStream getWithAttest(String path) throws IOException, AttestationResponseHandlerException {
+    private InputStream getWithAttest(String path) throws IOException, AttestationResponseHandlerException, CloudStorageException {
         if (!attestationResponseHandler.attested()) {
             attestationResponseHandler.attest();
         }
@@ -107,7 +107,7 @@ public class UidCoreClient implements IUidCoreClient, DownloadCloudStorage {
         HttpResponse<String> httpResponse;
         httpResponse = sendHttpRequest(path, attestationToken);
         if (httpResponse.statusCode() != 200) {
-            LOGGER.warn("Non-success response from core on request_url={} status_code={} response={}", path, httpResponse.statusCode(), httpResponse.body());
+            throw new CloudStorageException(String.format("Non-success response from core on request %s. Status code %d. Response %s", path, httpResponse.statusCode(), httpResponse.body()));
         }
         return Utils.convertHttpResponseToInputStream(httpResponse);
     }

--- a/src/main/java/com/uid2/shared/attest/UidCoreClient.java
+++ b/src/main/java/com/uid2/shared/attest/UidCoreClient.java
@@ -97,7 +97,7 @@ public class UidCoreClient implements IUidCoreClient, DownloadCloudStorage {
         return (proxy == null ? new URL(path).openConnection() : new URL(path).openConnection(proxy)).getInputStream();
     }
 
-    private InputStream getWithAttest(String path) throws IOException, AttestationResponseHandlerException {
+    private InputStream getWithAttest(String path) throws IOException, AttestationResponseHandlerException, CloudStorageException {
         if (!attestationResponseHandler.attested()) {
             attestationResponseHandler.attest();
         }
@@ -106,7 +106,9 @@ public class UidCoreClient implements IUidCoreClient, DownloadCloudStorage {
 
         HttpResponse<String> httpResponse;
         httpResponse = sendHttpRequest(path, attestationToken);
-
+//        if (httpResponse.statusCode() != 200) {
+//            throw new IOException(String.format("Non-success response from core on request to %s. Status code: %d, Response: %s", path, httpResponse.statusCode(), httpResponse.body()));
+//        }
         return Utils.convertHttpResponseToInputStream(httpResponse);
     }
 

--- a/src/test/java/com/uid2/shared/attest/UidCoreClientTest.java
+++ b/src/test/java/com/uid2/shared/attest/UidCoreClientTest.java
@@ -7,8 +7,6 @@ import com.uid2.shared.util.URLConnectionHttpClient;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.Proxy;
@@ -20,7 +18,6 @@ import static org.mockito.Mockito.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class UidCoreClientTest {
-    private static final Logger LOGGER = LoggerFactory.getLogger(UidCoreClientTest.class);
     private Proxy proxy = CloudUtils.defaultProxy;
     private AttestationResponseHandler mockAttestationResponseHandler = mock(AttestationResponseHandler.class);
 
@@ -50,6 +47,7 @@ public class UidCoreClientTest {
 
         String expectedResponseBody = "Hello, world!";
         when(mockHttpResponse.body()).thenReturn(expectedResponseBody);
+        when(mockHttpResponse.statusCode()).thenReturn(200);
 
         HashMap<String, String> expectedHeaders = new HashMap<>();
         expectedHeaders.put(Const.Http.AppVersionHeader, "testAppVersionHeader");

--- a/src/test/java/com/uid2/shared/attest/UidCoreClientTest.java
+++ b/src/test/java/com/uid2/shared/attest/UidCoreClientTest.java
@@ -7,6 +7,8 @@ import com.uid2.shared.util.URLConnectionHttpClient;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.Proxy;
@@ -18,6 +20,7 @@ import static org.mockito.Mockito.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class UidCoreClientTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(UidCoreClientTest.class);
     private Proxy proxy = CloudUtils.defaultProxy;
     private AttestationResponseHandler mockAttestationResponseHandler = mock(AttestationResponseHandler.class);
 
@@ -73,7 +76,7 @@ public class UidCoreClientTest {
     }
 
     @Test
-    public void Download_Attest401_getOptOut_NotCalled() throws CloudStorageException, IOException, AttestationResponseHandlerException {
+    public void Download_Attest401_getOptOut_NotCalled() throws IOException, AttestationResponseHandlerException {
         HttpResponse<String> mockHttpResponse = mock(HttpResponse.class);
         when(mockHttpResponse.statusCode()).thenReturn(401);
 
@@ -82,7 +85,10 @@ public class UidCoreClientTest {
 
         when(mockHttpClient.get(eq("https://download"), any(HashMap.class))).thenReturn(mockHttpResponse);
 
-        uidCoreClient.download("https://download");
+        assertThrows(CloudStorageException.class, () -> {
+            uidCoreClient.download("https://download");
+        });
+
         verify(mockAttestationResponseHandler, times(1)).attest();
         verify(mockAttestationResponseHandler, never()).getOptOutUrl();
     }


### PR DESCRIPTION
Previously, when a request to Core returns a non-successful response, we do not check the status code and try to parse the response as JSON. This throws a decode exception as shown below. 
<img width="1595" alt="Screenshot 2025-04-15 at 11 47 01 am" src="https://github.com/user-attachments/assets/952438a0-593c-4e79-bd11-97b3ecd3b225" />

Now, if the response has an unsuccessful status code, an exception will be thrown with the details of the response and request. This will make troubleshooting easier. 
<img width="1649" alt="Screenshot 2025-04-15 at 11 42 22 am" src="https://github.com/user-attachments/assets/5de86548-f0c5-44a2-910c-c6fedcfbcf56" />


