### PR TITLE
Add AuditLog V1

### DIFF
--- a/src/main/java/com/uid2/shared/audit/Audit.java
+++ b/src/main/java/com/uid2/shared/audit/Audit.java
@@ -142,6 +142,7 @@ public class Audit {
 
     private JsonObject filterQueryParams(MultiMap queryParamsMap, List<String> queryParams) {
         JsonObject queryParamsJson = new JsonObject();
+        if (queryParamsMap == null) return queryParamsJson;
         queryParamsMap.forEach(entry -> {
             if ( queryParams.contains(entry.getKey())) {
                 queryParamsJson.put(entry.getKey(), entry.getValue());

--- a/src/main/java/com/uid2/shared/audit/Audit.java
+++ b/src/main/java/com/uid2/shared/audit/Audit.java
@@ -1,0 +1,204 @@
+package com.uid2.shared.audit;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+class AuditRecord {
+    private final Instant timestamp;
+    private final String logType;
+    private final String source;
+    private final int status;
+    private final String method;
+    private final String endpoint;
+    private final String requestId;
+    private final JsonObject actor;
+    private final String forwardedRequestId;
+    private final JsonObject queryParams;
+    private final JsonObject requestBody;
+
+    private AuditRecord(Builder builder) {
+        this.timestamp = Instant.now();
+        this.logType = "audit";
+        this.source = AuditRecord.class.getPackage().getName();
+        this.status = builder.status;
+        this.method = builder.method;
+        this.endpoint = builder.endpoint;
+        this.requestId = builder.requestId;
+        this.actor = builder.actor;
+        this.forwardedRequestId = builder.forwardedRequestId;
+        this.queryParams = builder.queryParams;
+        this.requestBody = builder.requestBody;
+    }
+
+    public JsonObject toJson() {
+        JsonObject json = new JsonObject()
+                .put("timestamp", timestamp.toString())
+                .put("log_type", logType)
+                .put("source", source)
+                .put("status", status)
+                .put("method", method)
+                .put("endpoint", endpoint)
+                .put("request_id", requestId)
+                .put("actor", actor);
+        if (forwardedRequestId != null) json.put("forwarded_request_id", forwardedRequestId);
+        if (queryParams != null) json.put("query_params", queryParams);
+        if (requestBody != null) json.put("request_body", requestBody);
+        return json;
+    }
+
+    @Override
+    public String toString() {
+        return toJson().encode();
+    }
+
+    public static class Builder {
+        private String source;
+        private final int status;
+        private final String method;
+        private final String endpoint;
+        private final String requestId;
+        private final JsonObject actor;
+
+        private String forwardedRequestId;
+        private JsonObject queryParams;
+        private JsonObject requestBody;
+
+        public Builder(int status, String method, String endpoint, String requestId, JsonObject actor) {
+            this.status = status;
+            this.method = method;
+            this.endpoint = endpoint;
+            this.requestId = requestId;
+            this.actor = actor;
+        }
+
+        public Builder source(String source) {
+            this.source = source;
+            return this;
+        }
+
+        public Builder forwardedRequestId(String forwardedRequestId) {
+            this.forwardedRequestId = forwardedRequestId;
+            return this;
+        }
+
+        public Builder queryParams(JsonObject queryParams) {
+            this.queryParams = queryParams;
+            return this;
+        }
+
+        public Builder requestBody(JsonObject requestBody) {
+            this.requestBody = requestBody;
+            return this;
+        }
+
+        public AuditRecord build() {
+            return new AuditRecord(this);
+        }
+    }
+}
+
+public class Audit {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Audit.class);
+
+    private static Set<String> flattenToDotNotation(JsonObject json, String parentKey) {
+        Set<String> keys = new HashSet<>();
+
+        for (Map.Entry<String, Object> entry : json) {
+            String fullKey = parentKey.isEmpty() ? entry.getKey() : parentKey + "." + entry.getKey();
+            Object value = entry.getValue();
+
+            if (value instanceof JsonObject) {
+                keys.addAll(flattenToDotNotation((JsonObject) value, fullKey));
+            } else {
+                keys.add(fullKey);
+            }
+        }
+
+        return keys;
+    }
+
+    private static void removeByDotKey(JsonObject json, String dotKey) {
+        String[] parts = dotKey.split("\\.");
+        JsonObject current = json;
+        for (int i = 0; i < parts.length - 1; i++) {
+            Object next = current.getValue(parts[i]);
+            if (!(next instanceof JsonObject)) {
+                return;
+            }
+            current = (JsonObject) next;
+        }
+        current.remove(parts[parts.length - 1]);
+    }
+
+    private JsonObject filterQueryParams(MultiMap queryParamsMap, List<String> queryParams) {
+        JsonObject queryParamsJson = new JsonObject();
+        queryParamsMap.forEach(entry -> {
+            if ( queryParams.contains(entry.getKey())) {
+                queryParamsJson.put(entry.getKey(), entry.getValue());
+            }
+        });
+        return queryParamsJson;
+    }
+
+    private JsonObject filterBody(JsonObject bodyJson, List<String> bodyParams) {
+        Set<String> allowedKeys = bodyParams != null
+                ? new HashSet<>(bodyParams): null;
+        if (bodyJson != null && allowedKeys !=null ) {
+            Set<String> dotKeys = flattenToDotNotation(bodyJson, "");
+            for (String key : dotKeys) {
+                if (!allowedKeys.contains(key)) {
+                    removeByDotKey(bodyJson, key);
+                }
+            }
+        }
+        return bodyJson;
+    }
+
+    //move to shared
+    public void log(RoutingContext ctx, AuditParams params) {
+
+        JsonObject userDetails = ctx.get("userDetails");
+        if (userDetails == null) {
+            userDetails = new JsonObject();
+        }
+        userDetails.put("User-Agent",ctx.request().getHeader("User-Agent") );
+        userDetails.put("IP", ctx.request().remoteAddress().host() );
+
+        AuditRecord.Builder builder = new AuditRecord.Builder(
+                ctx.response().getStatusCode(),
+                ctx.request().method().name(),
+                ctx.request().path(),
+                ctx.request().getHeader("X-Amzn-Trace-Id"),
+                userDetails
+        );
+
+        if (params != null) {
+            JsonObject bodyJson = filterBody(ctx.body().asJsonObject(), params.bodyParams());
+            JsonObject queryParamsJson = filterQueryParams(ctx.request().params(), params.queryParams());
+            if (!queryParamsJson.isEmpty()) {
+                builder.queryParams(queryParamsJson);
+            }
+
+            if (bodyJson != null && !bodyJson.isEmpty()) {
+                builder.requestBody(bodyJson);
+            }
+        }
+
+        if (ctx.request().getHeader("UID2-Forwarded-Trace-Id") != null) {
+            builder.forwardedRequestId(ctx.request().getHeader("UID2-Forwarded-Trace-Id"));
+        }
+
+        AuditRecord auditRecord = builder.build();
+        LOGGER.info(auditRecord.toString());
+    }
+
+}

--- a/src/main/java/com/uid2/shared/audit/Audit.java
+++ b/src/main/java/com/uid2/shared/audit/Audit.java
@@ -163,7 +163,6 @@ public class Audit {
         return bodyJson;
     }
 
-    //move to shared
     public void log(RoutingContext ctx, AuditParams params) {
 
         JsonObject userDetails = ctx.get("userDetails");

--- a/src/main/java/com/uid2/shared/audit/AuditParams.java
+++ b/src/main/java/com/uid2/shared/audit/AuditParams.java
@@ -3,13 +3,18 @@ package com.uid2.shared.audit;
 import java.util.Collections;
 import java.util.List;
 
-public record AuditParams(List<String> queryParams, List<String> bodyParams) {
-    public AuditParams(List<String> queryParams, List<String> bodyParams) {
+public record AuditParams(String source, List<String> queryParams, List<String> bodyParams) {
+    public AuditParams(String source, List<String> queryParams, List<String> bodyParams) {
         this.queryParams = queryParams != null
                 ? Collections.unmodifiableList(queryParams)
                 : Collections.emptyList();
         this.bodyParams = bodyParams != null
                 ? Collections.unmodifiableList(bodyParams)
                 : Collections.emptyList();
+        this.source = source;
+    }
+
+    public AuditParams(String source) {
+        this(source, Collections.emptyList(), Collections.emptyList());
     }
 }

--- a/src/main/java/com/uid2/shared/audit/AuditParams.java
+++ b/src/main/java/com/uid2/shared/audit/AuditParams.java
@@ -1,0 +1,15 @@
+package com.uid2.shared.audit;
+
+import java.util.Collections;
+import java.util.List;
+
+public record AuditParams(List<String> queryParams, List<String> bodyParams) {
+    public AuditParams(List<String> queryParams, List<String> bodyParams) {
+        this.queryParams = queryParams != null
+                ? Collections.unmodifiableList(queryParams)
+                : Collections.emptyList();
+        this.bodyParams = bodyParams != null
+                ? Collections.unmodifiableList(bodyParams)
+                : Collections.emptyList();
+    }
+}

--- a/src/test/java/com/uid2/shared/audit/AuditTest.java
+++ b/src/test/java/com/uid2/shared/audit/AuditTest.java
@@ -1,0 +1,68 @@
+package com.uid2.shared.audit;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.vertx.ext.web.RoutingContext;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.net.SocketAddress;
+import static org.assertj.core.api.Assertions.assertThat;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.http.HttpMethod;
+
+public class AuditTest {
+
+    @Test
+    public void test_audit() {
+        // Arrange
+        RoutingContext mockCtx = Mockito.mock(RoutingContext.class);
+        HttpServerRequest mockRequest = Mockito.mock(HttpServerRequest.class);
+        Mockito.when(mockCtx.request()).thenReturn(mockRequest);
+        Mockito.when(mockRequest.getHeader("User-Agent")).thenReturn("JUnit-Test-Agent");
+        SocketAddress mockAddress = Mockito.mock(SocketAddress.class);
+        Mockito.when(mockAddress.toString()).thenReturn("127.0.0.1");
+        Mockito.when(mockRequest.remoteAddress()).thenReturn(mockAddress);
+        HttpServerResponse mockResponse = Mockito.mock(HttpServerResponse.class);
+        Mockito.when(mockCtx.response()).thenReturn(mockResponse);
+        Mockito.when(mockResponse.getStatusCode()).thenReturn(200);
+        Mockito.when(mockRequest.method()).thenReturn(HttpMethod.GET);
+        AuditParams params = null;
+
+        // Prepare logger capture
+        Logger logger = (Logger) LoggerFactory.getLogger(Audit.class);
+        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        listAppender.start();
+        logger.addAppender(listAppender);
+
+        Audit audit = new Audit();
+        audit.log(mockCtx, params);
+
+        boolean found = listAppender.list.stream()
+                .anyMatch(event -> event.getFormattedMessage().contains("GET"));
+
+        assertThat(found).isTrue();
+    }
+
+    @Test
+    public void test_audit_fail_silently() {
+        RoutingContext mockCtx = Mockito.mock(RoutingContext.class);
+        AuditParams params = null;
+
+        Logger logger = (Logger) LoggerFactory.getLogger(Audit.class);
+        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        listAppender.start();
+        logger.addAppender(listAppender);
+
+        Audit audit = new Audit();
+        audit.log(mockCtx, params);
+
+        boolean warnLogged = listAppender.list.stream()
+                .anyMatch(event -> event.getLevel() == Level.WARN && event.getFormattedMessage().contains("Failed"));
+
+        assertThat(warnLogged).isTrue();
+    }
+}

--- a/src/test/java/com/uid2/shared/audit/AuditTest.java
+++ b/src/test/java/com/uid2/shared/audit/AuditTest.java
@@ -4,6 +4,8 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RequestBody;
 import io.vertx.ext.web.RoutingContext;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -14,11 +16,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.HttpMethod;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class AuditTest {
 
     @Test
     public void test_audit() {
-        // Arrange
         RoutingContext mockCtx = Mockito.mock(RoutingContext.class);
         HttpServerRequest mockRequest = Mockito.mock(HttpServerRequest.class);
         Mockito.when(mockCtx.request()).thenReturn(mockRequest);
@@ -32,7 +36,7 @@ public class AuditTest {
         Mockito.when(mockRequest.method()).thenReturn(HttpMethod.GET);
         AuditParams params = null;
 
-        // Prepare logger capture
+
         Logger logger = (Logger) LoggerFactory.getLogger(Audit.class);
         ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
         listAppender.start();
@@ -64,5 +68,49 @@ public class AuditTest {
                 .anyMatch(event -> event.getLevel() == Level.WARN && event.getFormattedMessage().contains("Failed"));
 
         assertThat(warnLogged).isTrue();
+    }
+
+    @Test
+    public void test_dot_notations() {
+        RoutingContext mockCtx = Mockito.mock(RoutingContext.class);
+        HttpServerRequest mockRequest = Mockito.mock(HttpServerRequest.class);
+        Mockito.when(mockCtx.request()).thenReturn(mockRequest);
+        Mockito.when(mockRequest.getHeader("User-Agent")).thenReturn("JUnit-Test-Agent");
+        SocketAddress mockAddress = Mockito.mock(SocketAddress.class);
+        Mockito.when(mockAddress.toString()).thenReturn("127.0.0.1");
+        Mockito.when(mockRequest.remoteAddress()).thenReturn(mockAddress);
+        HttpServerResponse mockResponse = Mockito.mock(HttpServerResponse.class);
+        Mockito.when(mockCtx.response()).thenReturn(mockResponse);
+        Mockito.when(mockResponse.getStatusCode()).thenReturn(200);
+        Mockito.when(mockRequest.method()).thenReturn(HttpMethod.POST);
+        AuditParams params = new AuditParams(null, Arrays.asList("name.first", "location"));
+
+        RequestBody mockBody = Mockito.mock(RequestBody.class);
+
+        JsonObject json = new JsonObject()
+                .put("name", new JsonObject().put("first", "uid2_user"))
+                .put("location", "seattle");
+
+        Mockito.when(mockCtx.body()).thenReturn(mockBody);
+        Mockito.when(mockBody.asJsonObject()).thenReturn(json);
+
+        Logger logger = (Logger) LoggerFactory.getLogger(Audit.class);
+        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        listAppender.start();
+        logger.addAppender(listAppender);
+
+        Audit audit = new Audit();
+        audit.log(mockCtx, params);
+
+        List<String> messages = listAppender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+
+        assertThat(messages)
+                .anyMatch(msg -> msg.contains("uid2_user"));
+
+        assertThat(messages)
+                .anyMatch(msg -> msg.contains("seattle"));
+
     }
 }

--- a/src/test/java/com/uid2/shared/audit/AuditTest.java
+++ b/src/test/java/com/uid2/shared/audit/AuditTest.java
@@ -4,9 +4,11 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import io.vertx.core.MultiMap;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RequestBody;
 import io.vertx.ext.web.RoutingContext;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.LoggerFactory;
@@ -18,32 +20,41 @@ import io.vertx.core.http.HttpMethod;
 
 import java.util.Arrays;
 import java.util.List;
-
 public class AuditTest {
 
-    @Test
-    public void test_audit() {
-        RoutingContext mockCtx = Mockito.mock(RoutingContext.class);
-        HttpServerRequest mockRequest = Mockito.mock(HttpServerRequest.class);
+    private RoutingContext mockCtx;
+    private HttpServerRequest mockRequest;
+    private HttpServerResponse mockResponse;
+    private SocketAddress mockAddress;
+    private Logger logger;
+    private ListAppender<ILoggingEvent> listAppender;
+
+    @BeforeEach
+    public void setUp() {
+        mockCtx = Mockito.mock(RoutingContext.class);
+        mockRequest = Mockito.mock(HttpServerRequest.class);
+        mockResponse = Mockito.mock(HttpServerResponse.class);
+        mockAddress = Mockito.mock(SocketAddress.class);
+
         Mockito.when(mockCtx.request()).thenReturn(mockRequest);
-        Mockito.when(mockRequest.getHeader("User-Agent")).thenReturn("JUnit-Test-Agent");
-        SocketAddress mockAddress = Mockito.mock(SocketAddress.class);
-        Mockito.when(mockAddress.toString()).thenReturn("127.0.0.1");
-        Mockito.when(mockRequest.remoteAddress()).thenReturn(mockAddress);
-        HttpServerResponse mockResponse = Mockito.mock(HttpServerResponse.class);
         Mockito.when(mockCtx.response()).thenReturn(mockResponse);
+        Mockito.when(mockRequest.getHeader("User-Agent")).thenReturn("JUnit-Test-Agent");
+        Mockito.when(mockRequest.remoteAddress()).thenReturn(mockAddress);
+        Mockito.when(mockAddress.toString()).thenReturn("127.0.0.1");
         Mockito.when(mockResponse.getStatusCode()).thenReturn(200);
-        Mockito.when(mockRequest.method()).thenReturn(HttpMethod.GET);
-        AuditParams params = null;
 
-
-        Logger logger = (Logger) LoggerFactory.getLogger(Audit.class);
-        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+        logger = (Logger) LoggerFactory.getLogger(Audit.class);
+        listAppender = new ListAppender<>();
         listAppender.start();
         logger.addAppender(listAppender);
+    }
 
-        Audit audit = new Audit();
-        audit.log(mockCtx, params);
+    @Test
+    public void testAudit() {
+        Mockito.when(mockRequest.method()).thenReturn(HttpMethod.GET);
+        AuditParams params = new AuditParams("admin");
+
+        new Audit().log(mockCtx, params);
 
         boolean found = listAppender.list.stream()
                 .anyMatch(event -> event.getFormattedMessage().contains("GET"));
@@ -52,17 +63,8 @@ public class AuditTest {
     }
 
     @Test
-    public void test_audit_fail_silently() {
-        RoutingContext mockCtx = Mockito.mock(RoutingContext.class);
-        AuditParams params = null;
-
-        Logger logger = (Logger) LoggerFactory.getLogger(Audit.class);
-        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
-        listAppender.start();
-        logger.addAppender(listAppender);
-
-        Audit audit = new Audit();
-        audit.log(mockCtx, params);
+    public void testAuditFailSilently() {
+        new Audit().log(mockCtx, new AuditParams("admin"));
 
         boolean warnLogged = listAppender.list.stream()
                 .anyMatch(event -> event.getLevel() == Level.WARN && event.getFormattedMessage().contains("Failed"));
@@ -71,22 +73,20 @@ public class AuditTest {
     }
 
     @Test
-    public void test_dot_notations() {
-        RoutingContext mockCtx = Mockito.mock(RoutingContext.class);
-        HttpServerRequest mockRequest = Mockito.mock(HttpServerRequest.class);
-        Mockito.when(mockCtx.request()).thenReturn(mockRequest);
-        Mockito.when(mockRequest.getHeader("User-Agent")).thenReturn("JUnit-Test-Agent");
-        SocketAddress mockAddress = Mockito.mock(SocketAddress.class);
-        Mockito.when(mockAddress.toString()).thenReturn("127.0.0.1");
-        Mockito.when(mockRequest.remoteAddress()).thenReturn(mockAddress);
-        HttpServerResponse mockResponse = Mockito.mock(HttpServerResponse.class);
-        Mockito.when(mockCtx.response()).thenReturn(mockResponse);
-        Mockito.when(mockResponse.getStatusCode()).thenReturn(200);
+    public void testAuditThrowsExceptionWhenSourceIsNotSpecified() {
+        try {
+            new Audit().log(mockCtx, null);
+        } catch (Exception e) {
+            assertThat(e).isInstanceOf(NullPointerException.class);
+        }
+    }
+
+    @Test
+    public void testBodyParams() {
         Mockito.when(mockRequest.method()).thenReturn(HttpMethod.POST);
-        AuditParams params = new AuditParams(null, Arrays.asList("name.first", "location"));
+        AuditParams params = new AuditParams("admin", null, Arrays.asList("name.first", "location"));
 
         RequestBody mockBody = Mockito.mock(RequestBody.class);
-
         JsonObject json = new JsonObject()
                 .put("name", new JsonObject().put("first", "uid2_user"))
                 .put("location", "seattle");
@@ -94,23 +94,31 @@ public class AuditTest {
         Mockito.when(mockCtx.body()).thenReturn(mockBody);
         Mockito.when(mockBody.asJsonObject()).thenReturn(json);
 
-        Logger logger = (Logger) LoggerFactory.getLogger(Audit.class);
-        ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
-        listAppender.start();
-        logger.addAppender(listAppender);
-
-        Audit audit = new Audit();
-        audit.log(mockCtx, params);
+        new Audit().log(mockCtx, params);
 
         List<String> messages = listAppender.list.stream()
                 .map(ILoggingEvent::getFormattedMessage)
                 .toList();
 
-        assertThat(messages)
-                .anyMatch(msg -> msg.contains("uid2_user"));
+        assertThat(messages).anyMatch(msg -> msg.contains("uid2_user"));
+        assertThat(messages).anyMatch(msg -> msg.contains("seattle"));
+    }
 
-        assertThat(messages)
-                .anyMatch(msg -> msg.contains("seattle"));
+    @Test
+    public void testQueryParams() {
+        Mockito.when(mockRequest.method()).thenReturn(HttpMethod.POST);
+        AuditParams params = new AuditParams("admin", Arrays.asList("location"), null);
 
+        MultiMap queryParams = MultiMap.caseInsensitiveMultiMap();
+        queryParams.add("location", "seattle");
+
+        Mockito.when(mockCtx.request().params()).thenReturn(queryParams);
+        new Audit().log(mockCtx, params);
+
+        List<String> messages = listAppender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+
+        assertThat(messages).anyMatch(msg -> msg.contains("seattle"));
     }
 }


### PR DESCRIPTION
Add Audit Log, Alpha version. 

Defines a structured AuditRecord , can pass queryParams field, bodyParams fields (dot notation support for body params) . Idea to not fail in audit log, we log max information possible, if none, we log the failure. 

Usage 

```
private Handler<RoutingContext> logAndHandle(Handler<RoutingContext> handler, AuditParams params) {
        return ctx -> {
            ctx.addBodyEndHandler(v -> this.audit.log(ctx, params));
            handler.handle(ctx);
        };
    }
```

```
router.get("/api/site/:siteId").handler(
                auth.handle(this::handleSiteById, new AuditParams(Arrays.asList("x", "y"), null), Role.MAINTAINER,
                        Role.SHARING_PORTAL));
  router.post("/api/site/enable").blockingHandler(auth.handle((ctx) -> {
            synchronized (writeLock) {
                this.handleSiteEnable(ctx);
            }
        }, new AuditParams(Arrays.asList("x", "y"), Arrays.asList("name.first", "location")), Role.MAINTAINER)
 );
```
