### PR TITLE
Added SdkClientException to verbose catch block

### DIFF
--- a/src/main/java/com/uid2/shared/cloud/CloudStorageS3.java
+++ b/src/main/java/com/uid2/shared/cloud/CloudStorageS3.java
@@ -1,6 +1,7 @@
 package com.uid2.shared.cloud;
 
 import com.amazonaws.HttpMethod;
+import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -141,6 +142,8 @@ public class CloudStorageS3 implements TaggableCloudStorage {
             } else {
                 throw new CloudStorageException("s3 get error: " + e.getClass().getSimpleName() + ": " + bucket + (verbose ? " - " + e.getMessage() : ""));
             }
+        } catch (SdkClientException e) {
+            throw new CloudStorageException("s3 get error: " + e.getClass().getSimpleName() + ": " + bucket + (verbose ? " - " + e.getMessage() : ""));
         } catch (Throwable t) {
             // Do not log the message or the original exception as that may contain the pre-signed url
             throw new CloudStorageException("s3 get error: " + t.getClass().getSimpleName() + ": " + bucket);


### PR DESCRIPTION
Tested locally:
* Recreated `SdkClientException` by starting admin without localstack
```
16:36:25.135 thread=vert.x-eventloop-thread-0 level=ERROR class=com.uid2.admin.Main - failed to initialize admin verticle com.uid2.shared.cloud.CloudStorageException: s3 get error: SdkClientException: test-core-bucket - Unable to execute HTTP request: Connect to localhost:5001 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused: getsockopt
```

* Mockito testing to simulate `SdkClientException` being thrown