### PR TITLE
Validate fields in audit log

### DIFF
--- a/src/main/java/com/uid2/shared/audit/Audit.java
+++ b/src/main/java/com/uid2/shared/audit/Audit.java
@@ -38,9 +38,6 @@ public class Audit {
         private static final Pattern UID2_KEY_PATTERN = Pattern.compile("(UID2|EUID)-[A-Za-z]-[A-Za-z]-[A-Za-z0-9_-]+");
         private static final int PARAMETER_MAX_LENGTH = 1000;
         private static final int REQUEST_BODY_MAX_LENGTH = 10000;
-
-        private static final Pattern UID_INSTANCE_ID_SUFFIX_PATTERN = Pattern.compile("^[A-Za-z0-9\\-]+-[0-9a-f]{1,16}$");
-
         private final StringBuilder toJsonValidationErrorMessageBuilder = new StringBuilder();
         @Getter
         private String toJsonValidationErrorMessage = "";
@@ -201,11 +198,11 @@ public class Audit {
         }
 
         private boolean validateUIDInstanceId(String uidInstanceId) {
-            if(!UID_INSTANCE_ID_SUFFIX_PATTERN.matcher(uidInstanceId).matches() && !uidInstanceId.equals(UNKNOWN_ID)) {
+            if(uidInstanceId.length() < 100 && validateNoSecrets(uidInstanceId, "uid_instance_id") && validateNoSQL(uidInstanceId, "uid_instance_id") ) {
+                return true;
+            } else {
                 toJsonValidationErrorMessageBuilder.append("Malformed uid_instance_id found in the audit log. ");
                 return false;
-            } else {
-                return true;
             }
         }
 

--- a/src/main/java/com/uid2/shared/audit/Audit.java
+++ b/src/main/java/com/uid2/shared/audit/Audit.java
@@ -35,9 +35,6 @@ public class Audit {
         private final JsonObject queryParams;
         private final String uidInstanceId;
         private final String requestBody;
-        private static final Pattern UID2_KEY_PATTERN = Pattern.compile("(UID2|EUID)-[A-Za-z]-[A-Za-z]-[A-Za-z0-9_-]+");
-        private static final int PARAMETER_MAX_LENGTH = 1000;
-        private static final int REQUEST_BODY_MAX_LENGTH = 10000;
         private final StringBuilder toJsonValidationErrorMessageBuilder = new StringBuilder();
         @Getter
         private String toJsonValidationErrorMessage = "";
@@ -106,8 +103,9 @@ public class Audit {
                     keysToRemove.add(key);
                 }
 
-                if (val != null && val.length() > PARAMETER_MAX_LENGTH) {
-                    val = val.substring(0, PARAMETER_MAX_LENGTH);
+                int parameter_max_length = 1000;
+                if (val != null && val.length() > parameter_max_length) {
+                    val = val.substring(0, parameter_max_length);
                     toJsonValidationErrorMessageBuilder.append(String.format(
                             "The %s is too long in the audit log: %s. ", propertyName, key));
                 }
@@ -162,8 +160,9 @@ public class Audit {
 
             }
 
-            if (sanitizedRequestBody.length() > REQUEST_BODY_MAX_LENGTH) {
-                sanitizedRequestBody = sanitizedRequestBody.substring(0, REQUEST_BODY_MAX_LENGTH);
+            int request_body_max_length = 10000;
+            if (sanitizedRequestBody.length() > request_body_max_length) {
+                sanitizedRequestBody = sanitizedRequestBody.substring(0, request_body_max_length);
                 toJsonValidationErrorMessageBuilder.append("Request body is too long in the audit log: %s. ");
             }
             return sanitizedRequestBody;
@@ -173,7 +172,8 @@ public class Audit {
             if (fieldValue == null || fieldValue.isEmpty()) {
                 return true;
             }
-            Matcher matcher = UID2_KEY_PATTERN.matcher(fieldValue);
+            Pattern uid2_key_pattern = Pattern.compile("(UID2|EUID)-[A-Za-z]-[A-Za-z]-[A-Za-z0-9_-]+");
+            Matcher matcher = uid2_key_pattern.matcher(fieldValue);
             if(matcher.find()) {
                 toJsonValidationErrorMessageBuilder.append(String.format("Secret found in the audit log: %s. ", propertyName));
                 return false;

--- a/src/main/java/com/uid2/shared/audit/Audit.java
+++ b/src/main/java/com/uid2/shared/audit/Audit.java
@@ -64,15 +64,15 @@ public class Audit {
                     .put("endpoint", endpoint)
                     .put("trace_id", traceId);
 
-            if (traceId != null && validateAmazonTraceId(traceId, "trace_id")) {
+            if (traceId != null && validateId(traceId, "trace_id")) {
                 json.put("trace_id", traceId);
             }
 
-            if (uidTraceId != null && validateAmazonTraceId(uidTraceId, "uid_trace_id")) {
+            if (uidTraceId != null && validateId(uidTraceId, "uid_trace_id")) {
                 json.put("uid_trace_id", uidTraceId);
             }
 
-            if (uidInstanceId != null && validateUIDInstanceId(uidInstanceId)) {
+            if (uidInstanceId != null && validateId(uidInstanceId, "uid_instance_id")) {
                 json.put("uid_instance_id", uidInstanceId);
             }
             actor.put("id", this.getLogIdentifier(json));
@@ -197,25 +197,12 @@ public class Audit {
             }
         }
 
-        private boolean validateUIDInstanceId(String uidInstanceId) {
-            if(uidInstanceId.length() < 100 && validateNoSecrets(uidInstanceId, "uid_instance_id") && validateNoSQL(uidInstanceId, "uid_instance_id") ) {
+        private boolean validateId(String uidInstanceId, String propertyName) {
+            if(uidInstanceId.length() < 100 && validateNoSecrets(uidInstanceId, propertyName) && validateNoSQL(uidInstanceId, propertyName) ) {
                 return true;
             } else {
                 toJsonValidationErrorMessageBuilder.append("Malformed uid_instance_id found in the audit log. ");
                 return false;
-            }
-        }
-
-        private boolean validateAmazonTraceId(String traceId, String propertyName) {
-            Pattern x_amzn_trace_id_pattern = Pattern.compile(
-                    "(?:Root|Self)=1-[0-9a-fA-F]{8}-[0-9a-fA-F]{24}"
-            ); // https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-request-tracing.html
-
-            if(!x_amzn_trace_id_pattern.matcher(traceId).matches() && !traceId.equals(UNKNOWN_ID)) {
-                toJsonValidationErrorMessageBuilder.append(String.format("Malformed %s found in the audit log. ", propertyName));
-                return false;
-            } else {
-                return true;
             }
         }
 

--- a/src/main/java/com/uid2/shared/audit/Audit.java
+++ b/src/main/java/com/uid2/shared/audit/Audit.java
@@ -61,8 +61,7 @@ public class Audit {
                     .put("source", source)
                     .put("status", status)
                     .put("method", method)
-                    .put("endpoint", endpoint)
-                    .put("trace_id", traceId);
+                    .put("endpoint", endpoint);
 
             if (traceId != null && validateId(traceId, "trace_id")) {
                 json.put("trace_id", traceId);
@@ -201,7 +200,7 @@ public class Audit {
             if(uidInstanceId.length() < 100 && validateNoSecrets(uidInstanceId, propertyName) && validateNoSQL(uidInstanceId, propertyName) ) {
                 return true;
             } else {
-                toJsonValidationErrorMessageBuilder.append("Malformed uid_instance_id found in the audit log. ");
+                toJsonValidationErrorMessageBuilder.append(String.format("Malformed %s found in the audit log. ", propertyName));
                 return false;
             }
         }

--- a/src/test/java/com/uid2/shared/audit/AuditTest.java
+++ b/src/test/java/com/uid2/shared/audit/AuditTest.java
@@ -19,6 +19,9 @@ import org.mockito.Mockito;
 import org.slf4j.LoggerFactory;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.net.SocketAddress;
+
+import static com.uid2.shared.audit.Audit.UID_INSTANCE_ID_HEADER;
+import static com.uid2.shared.audit.Audit.UID_TRACE_ID_HEADER;
 import static org.assertj.core.api.Assertions.assertThat;
 import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.http.HttpMethod;
@@ -35,6 +38,16 @@ public class AuditTest {
     private SocketAddress mockAddress;
     private Logger logger;
     private ListAppender<ILoggingEvent> listAppender;
+    private String UID2_SECRET_KEY = "UID2-O-P-AB12cd34EF-zyX9_abCDEFghijklMNOPQRSTuvwxYZ0123";
+    private String SECRET = "jhgjy6tuygiuhi";
+    private String SQL_STATEMENT = "SELECT * FROM users WHERE username = '' OR '1'='1'";
+    private String TRACE_ID = "Root=1-6825017b-2321f2302b5ea904340c1cff";
+    private String UID_TRACE_ID = "Root=1-6825017b-2321f2302b5ea904340c1cfa";
+    private String MALFORMED_TRACE_ID = "Root=1-6825017b-2321f2302b5ea904df340c1ckgg";
+    private String AMZN_TRACE_ID_HEADER = "X-Amzn-Trace-Id";
+    private String UID_INSTANCE_ID = "uid2-prod-use2-operator-6bb87b7fd-n4smk-90527e73fbffa91c";
+    private String MALFORMED_UID_INSTANCE_ID = "uid2-prod-use2-operator-6bb87b7fd-n4smk-90527e73fbffa91c-u";
+
 
     @BeforeEach
     public void setUp() {
@@ -124,6 +137,69 @@ public class AuditTest {
     }
 
     @Test
+    public void testBodyParamsAsJsobObjectWithSecret() {
+        Mockito.when(mockRequest.method()).thenReturn(HttpMethod.POST);
+        AuditParams params = new AuditParams(null, Arrays.asList("name.first", "location", UID2_SECRET_KEY));
+
+        RequestBody mockBody = Mockito.mock(RequestBody.class);
+        JsonObject json = new JsonObject()
+                .put("name", new JsonObject().put("first", "uid2_user"))
+                .put("location", "seattle")
+                .put(UID2_SECRET_KEY, SECRET);
+
+        Mockito.when(mockCtx.body()).thenReturn(mockBody);
+        Mockito.when(mockBody.buffer()).thenReturn(Buffer.buffer(json.toString()));
+
+        new Audit("admin").log(mockCtx, params);
+
+        List<String> messages = listAppender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+
+        assertThat(messages).allMatch(msg -> msg.contains("uid2_user") && msg.contains("seattle"));
+        assertThat(messages).noneMatch(msg -> msg.contains(UID2_SECRET_KEY));
+        assertThat(messages).noneMatch(msg -> msg.contains(SECRET));
+
+        boolean errorLogged = listAppender.list.stream()
+                .anyMatch(event -> event.getLevel() == Level.ERROR && event.getFormattedMessage().contains("Secret found in the audit log: request_body."));
+
+        assertThat(errorLogged).isTrue();
+    }
+
+    @Test
+    public void testBodyParamsAsJsobObjectWithSecretNSQL() {
+        Mockito.when(mockRequest.method()).thenReturn(HttpMethod.POST);
+        AuditParams params = new AuditParams(null, Arrays.asList("name.first", "location", UID2_SECRET_KEY, SQL_STATEMENT));
+
+        RequestBody mockBody = Mockito.mock(RequestBody.class);
+        JsonObject json = new JsonObject()
+                .put("name", new JsonObject().put("first", "uid2_user"))
+                .put("location", "seattle")
+                .put(UID2_SECRET_KEY, SECRET)
+                .put(SQL_STATEMENT, "weather");
+
+        Mockito.when(mockCtx.body()).thenReturn(mockBody);
+        Mockito.when(mockBody.buffer()).thenReturn(Buffer.buffer(json.toString()));
+
+        new Audit("admin").log(mockCtx, params);
+
+        List<String> messages = listAppender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+
+        assertThat(messages).allMatch(msg -> msg.contains("uid2_user") && msg.contains("seattle"));
+        assertThat(messages).noneMatch(msg -> msg.contains(UID2_SECRET_KEY));
+        assertThat(messages).noneMatch(msg -> msg.contains(SECRET));
+        assertThat(messages).noneMatch(msg -> msg.contains(SQL_STATEMENT));
+        assertThat(messages).noneMatch(msg -> msg.contains("weather"));
+
+        boolean errorLogged = listAppender.list.stream()
+                .anyMatch(event -> event.getLevel() == Level.ERROR && event.getFormattedMessage().contains("Secret found in the audit log: request_body.") && event.getFormattedMessage().contains("SQL injection found in the audit log: request_body."));
+
+        assertThat(errorLogged).isTrue();
+    }
+
+    @Test
     public void testBodyParamsAsJsobObjectWithSelectedBodyParams() {
         Mockito.when(mockRequest.method()).thenReturn(HttpMethod.POST);
         AuditParams params = new AuditParams(null, Arrays.asList("name.first"));
@@ -169,6 +245,69 @@ public class AuditTest {
     }
 
     @Test
+    public void testBodyParamsAsJsonArrayWithSecret() {
+        Mockito.when(mockRequest.method()).thenReturn(HttpMethod.POST);
+        AuditParams params = new AuditParams(null, Arrays.asList("partner_id", "config", UID2_SECRET_KEY));
+
+        RequestBody mockBody = Mockito.mock(RequestBody.class);
+        JsonArray json = new JsonArray()
+                .add(new JsonObject().put("partner_id", "1").put("config", "config1"))
+                .add(new JsonObject().put("partner_id", "2").put("config", "config2"))
+                .add(new JsonObject().put(UID2_SECRET_KEY, SECRET).put("config", "config3"));
+
+        Mockito.when(mockCtx.body()).thenReturn(mockBody);
+        Mockito.when(mockBody.buffer()).thenReturn(Buffer.buffer(json.toString()));
+
+        new Audit("admin").log(mockCtx, params);
+
+        List<String> messages = listAppender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+
+        assertThat(messages).allMatch(msg -> msg.contains("partner_id") && msg.contains("config"));
+        assertThat(messages).noneMatch(msg -> msg.contains(UID2_SECRET_KEY));
+        assertThat(messages).noneMatch(msg -> msg.contains(SECRET));
+
+        boolean errorLogged = listAppender.list.stream()
+                .anyMatch(event -> event.getLevel() == Level.ERROR && event.getFormattedMessage().contains("Secret found in the audit log: request_body."));
+
+        assertThat(errorLogged).isTrue();
+    }
+
+    @Test
+    public void testBodyParamsAsJsonArrayWithSecretNSQL() {
+        Mockito.when(mockRequest.method()).thenReturn(HttpMethod.POST);
+        AuditParams params = new AuditParams(null, Arrays.asList("partner_id", "config", UID2_SECRET_KEY, "weather"));
+
+        RequestBody mockBody = Mockito.mock(RequestBody.class);
+        JsonArray json = new JsonArray()
+                .add(new JsonObject().put("partner_id", "1").put("config", "config1"))
+                .add(new JsonObject().put("partner_id", "2").put("config", "config2"))
+                .add(new JsonObject().put(UID2_SECRET_KEY, SECRET).put("config", "config3"))
+                .add(new JsonObject().put("weather", SQL_STATEMENT).put("config", "config3"));
+
+        Mockito.when(mockCtx.body()).thenReturn(mockBody);
+        Mockito.when(mockBody.buffer()).thenReturn(Buffer.buffer(json.toString()));
+
+        new Audit("admin").log(mockCtx, params);
+
+        List<String> messages = listAppender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+
+        assertThat(messages).allMatch(msg -> msg.contains("partner_id") && msg.contains("config"));
+        assertThat(messages).noneMatch(msg -> msg.contains(UID2_SECRET_KEY));
+        assertThat(messages).noneMatch(msg -> msg.contains(SECRET));
+        assertThat(messages).noneMatch(msg -> msg.contains(SQL_STATEMENT));
+        assertThat(messages).noneMatch(msg -> msg.contains("weather"));
+
+        boolean errorLogged = listAppender.list.stream()
+                .anyMatch(event -> event.getLevel() == Level.ERROR && event.getFormattedMessage().contains("Secret found in the audit log: request_body.") && event.getFormattedMessage().contains("SQL injection found in the audit log: request_body."));
+
+        assertThat(errorLogged).isTrue();
+    }
+
+    @Test
     public void testBodyParamsAsJsonArrayWithSelectedBodyParams() {
         Mockito.when(mockRequest.method()).thenReturn(HttpMethod.POST);
         AuditParams params = new AuditParams(null, Arrays.asList("config"));
@@ -207,5 +346,237 @@ public class AuditTest {
                 .toList();
 
         assertThat(messages).anyMatch(msg -> msg.contains("seattle"));
+    }
+
+    @Test
+    public void testQueryParamsContainsSecrets() {
+        Mockito.when(mockRequest.method()).thenReturn(HttpMethod.POST);
+        AuditParams params = new AuditParams(Arrays.asList(UID2_SECRET_KEY, "location"), null);
+
+        MultiMap queryParams = MultiMap.caseInsensitiveMultiMap();
+        queryParams.add(UID2_SECRET_KEY, SECRET);
+        queryParams.add("location", "seattle");
+
+        Mockito.when(mockCtx.request().params()).thenReturn(queryParams);
+        new Audit("admin").log(mockCtx, params);
+
+        List<String> messages = listAppender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+
+        assertThat(messages).anyMatch(msg -> msg.contains("seattle"));
+        assertThat(messages).noneMatch(msg -> msg.contains(UID2_SECRET_KEY));
+        assertThat(messages).noneMatch(msg -> msg.contains(SECRET));
+
+        boolean errorLogged = listAppender.list.stream()
+                .anyMatch(event -> event.getLevel() == Level.ERROR && event.getFormattedMessage().contains("Secret found in the audit log: query_params."));
+
+        assertThat(errorLogged).isTrue();
+    }
+
+    @Test
+    public void testQueryParamsContainsSQL() {
+        Mockito.when(mockRequest.method()).thenReturn(HttpMethod.POST);
+        AuditParams params = new AuditParams(Arrays.asList("weather", "location"), null);
+
+        MultiMap queryParams = MultiMap.caseInsensitiveMultiMap();
+        queryParams.add("weather", SQL_STATEMENT);
+        queryParams.add("location", "seattle");
+
+        Mockito.when(mockCtx.request().params()).thenReturn(queryParams);
+        new Audit("admin").log(mockCtx, params);
+
+        List<String> messages = listAppender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+
+        assertThat(messages).anyMatch(msg -> msg.contains("seattle"));
+        assertThat(messages).noneMatch(msg -> msg.contains("weather"));
+        assertThat(messages).noneMatch(msg -> msg.contains(SQL_STATEMENT));
+
+        boolean errorLogged = listAppender.list.stream()
+                .anyMatch(event -> event.getLevel() == Level.ERROR && event.getFormattedMessage().contains("SQL injection found in the audit log: query_params."));
+
+        assertThat(errorLogged).isTrue();
+    }
+
+    @Test
+    public void testQueryParamsContainsSecretNSQL() {
+        Mockito.when(mockRequest.method()).thenReturn(HttpMethod.POST);
+        AuditParams params = new AuditParams(Arrays.asList(UID2_SECRET_KEY, "weather", "location"), null);
+
+        MultiMap queryParams = MultiMap.caseInsensitiveMultiMap();
+        queryParams.add("weather", SQL_STATEMENT);
+        queryParams.add("location", "seattle");
+        queryParams.add(UID2_SECRET_KEY, SECRET);
+
+        Mockito.when(mockCtx.request().params()).thenReturn(queryParams);
+        new Audit("admin").log(mockCtx, params);
+
+        List<String> messages = listAppender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+
+        assertThat(messages).anyMatch(msg -> msg.contains("seattle"));
+        assertThat(messages).noneMatch(msg -> msg.contains("weather"));
+        assertThat(messages).noneMatch(msg -> msg.contains(SQL_STATEMENT));
+        assertThat(messages).noneMatch(msg -> msg.contains(UID2_SECRET_KEY));
+        assertThat(messages).noneMatch(msg -> msg.contains(SECRET));
+
+        boolean errorLogged = listAppender.list.stream()
+                .anyMatch(event -> event.getLevel() == Level.ERROR && event.getFormattedMessage().contains("Secret found in the audit log: query_params.") && event.getFormattedMessage().contains("SQL injection found in the audit log: query_params."));
+
+        assertThat(errorLogged).isTrue();
+    }
+
+    @Test
+    public void testTraceId() throws JsonProcessingException {
+        Mockito.when(mockRequest.getHeader(AMZN_TRACE_ID_HEADER)).thenReturn(TRACE_ID);
+        AuditParams params = new AuditParams();
+
+        new Audit("admin").log(mockCtx, params);
+
+        Optional<ILoggingEvent> maybeEvent = listAppender.list.stream()
+                .filter(event -> event.getFormattedMessage().contains("trace_id"))
+                .findFirst();
+        String jsonLog = maybeEvent.get().getFormattedMessage();
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonNode = mapper.readTree(jsonLog);
+
+        assertThat(jsonNode.get("trace_id").asText()).isEqualTo(TRACE_ID);
+        assertThat(jsonNode.get("uid_trace_id").asText()).isEqualTo(TRACE_ID);
+    }
+
+    @Test
+    public void testMalformedTraceId() {
+        Mockito.when(mockRequest.getHeader(AMZN_TRACE_ID_HEADER)).thenReturn(MALFORMED_TRACE_ID);
+        AuditParams params = new AuditParams();
+
+        new Audit("admin").log(mockCtx, params);
+
+        List<String> messages = listAppender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+
+        assertThat(messages).anyMatch(msg -> msg.contains(MALFORMED_TRACE_ID));
+
+        boolean errorLogged = listAppender.list.stream()
+                .anyMatch(event -> event.getLevel() == Level.ERROR && event.getFormattedMessage().contains("Malformed trace_id found in the audit log. Malformed uid_trace_id found in the audit log."));
+
+        assertThat(errorLogged).isTrue();
+    }
+
+    @Test
+    public void testUIDTraceId() throws JsonProcessingException {
+        Mockito.when(mockRequest.getHeader(AMZN_TRACE_ID_HEADER)).thenReturn(TRACE_ID);
+        Mockito.when(mockRequest.getHeader(UID_TRACE_ID_HEADER)).thenReturn(UID_TRACE_ID);
+        AuditParams params = new AuditParams();
+
+        new Audit("admin").log(mockCtx, params);
+
+        Optional<ILoggingEvent> maybeEvent = listAppender.list.stream()
+                .filter(event -> event.getFormattedMessage().contains("trace_id"))
+                .findFirst();
+        String jsonLog = maybeEvent.get().getFormattedMessage();
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonNode = mapper.readTree(jsonLog);
+
+        assertThat(jsonNode.get("trace_id").asText()).isEqualTo(TRACE_ID);
+        assertThat(jsonNode.get("uid_trace_id").asText()).isEqualTo(UID_TRACE_ID);
+    }
+
+    @Test
+    public void testMalformedUIDTraceId() {
+        Mockito.when(mockRequest.getHeader(AMZN_TRACE_ID_HEADER)).thenReturn(TRACE_ID);
+        Mockito.when(mockRequest.getHeader(UID_TRACE_ID_HEADER)).thenReturn(MALFORMED_TRACE_ID);
+        AuditParams params = new AuditParams();
+
+        new Audit("admin").log(mockCtx, params);
+
+        List<String> messages = listAppender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+
+        assertThat(messages).anyMatch(msg -> msg.contains(TRACE_ID));
+        assertThat(messages).noneMatch(msg -> msg.contains(UID_TRACE_ID));
+
+        boolean errorLogged = listAppender.list.stream()
+                .anyMatch(event -> event.getLevel() == Level.ERROR && event.getFormattedMessage().contains("Malformed uid_trace_id found in the audit log."));
+
+        assertThat(errorLogged).isTrue();
+    }
+
+    @Test
+    public void testMalformedUIDInstanceId() {
+        Mockito.when(mockRequest.getHeader(UID_INSTANCE_ID_HEADER)).thenReturn(TRACE_ID);
+        AuditParams params = new AuditParams();
+
+        new Audit("admin").log(mockCtx, params);
+
+        List<String> messages = listAppender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+
+        assertThat(messages).noneMatch(msg -> msg.contains(TRACE_ID));
+
+        boolean errorLogged = listAppender.list.stream()
+                .anyMatch(event -> event.getLevel() == Level.ERROR && event.getFormattedMessage().contains("Malformed uid_instance_id found in the audit log. "));
+
+        assertThat(errorLogged).isTrue();
+    }
+
+    @Test
+    public void testAnotherMalformedUIDInstanceId() {
+        Mockito.when(mockRequest.getHeader(UID_INSTANCE_ID_HEADER)).thenReturn(MALFORMED_UID_INSTANCE_ID);
+        AuditParams params = new AuditParams();
+
+        new Audit("admin").log(mockCtx, params);
+
+        List<String> messages = listAppender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .toList();
+
+        assertThat(messages).noneMatch(msg -> msg.contains(TRACE_ID));
+
+        boolean errorLogged = listAppender.list.stream()
+                .anyMatch(event -> event.getLevel() == Level.ERROR && event.getFormattedMessage().contains("Malformed uid_instance_id found in the audit log. "));
+
+        assertThat(errorLogged).isTrue();
+    }
+
+    @Test
+    public void testMalformedUIDInstanceIdNull() throws JsonProcessingException {
+        Mockito.when(mockRequest.getHeader(UID_INSTANCE_ID_HEADER)).thenReturn(null);
+        AuditParams params = new AuditParams();
+
+        new Audit("admin").log(mockCtx, params);
+
+
+        Optional<ILoggingEvent> maybeEvent = listAppender.list.stream()
+                .filter(event -> event.getFormattedMessage().contains("uid_instance_id"))
+                .findFirst();
+        String jsonLog = maybeEvent.get().getFormattedMessage();
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonNode = mapper.readTree(jsonLog);
+
+        assertThat(jsonNode.get("uid_instance_id").asText()).isEqualTo("unknown");
+    }
+
+    @Test
+    public void testUIDInstanceIdWithKubernetes() throws JsonProcessingException {
+        Mockito.when(mockRequest.getHeader(UID_INSTANCE_ID_HEADER)).thenReturn(UID_INSTANCE_ID);
+        AuditParams params = new AuditParams();
+
+        new Audit("admin").log(mockCtx, params);
+
+
+        Optional<ILoggingEvent> maybeEvent = listAppender.list.stream()
+                .filter(event -> event.getFormattedMessage().contains("uid_instance_id"))
+                .findFirst();
+        String jsonLog = maybeEvent.get().getFormattedMessage();
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonNode = mapper.readTree(jsonLog);
+
+        assertThat(jsonNode.get("uid_instance_id").asText()).isEqualTo(UID_INSTANCE_ID);
     }
 }

--- a/src/test/java/com/uid2/shared/audit/AuditTest.java
+++ b/src/test/java/com/uid2/shared/audit/AuditTest.java
@@ -45,7 +45,9 @@ public class AuditTest {
     private String UID_TRACE_ID = "Root=1-6825017b-2321f2302b5ea904340c1cfa";
     private String MALFORMED_TRACE_ID = "Root=1-6825017b-2321f2302b5ea904df340c1ckgg";
     private String AMZN_TRACE_ID_HEADER = "X-Amzn-Trace-Id";
-    private String UID_INSTANCE_ID = "uid2-prod-use2-operator-6bb87b7fd-n4smk-90527e73fbffa91c";
+    private String UID_INSTANCE_ID_FROM_INTEG = "uid2-integ-use2-operator-dfb4bd68d-v9p6t-a2cf5882f000d7b2";
+    private String UID_INSTANCE_ID_FROM_PROD = "uid2-prod-use2-operator-6bb87b7fd-n4smk-90527e73fbffa91c";
+    private String UID_INSTANCE_ID_FROM_AWS = "aws-aasdadada-ami-12312311321-v9p6t-a2cf5882f000d7b2";
     private String MALFORMED_UID_INSTANCE_ID = "uid2-prod-use2-operator-6bb87b7fd-n4smk-90527e73fbffa91c-u";
 
 
@@ -563,8 +565,8 @@ public class AuditTest {
     }
 
     @Test
-    public void testUIDInstanceIdWithKubernetes() throws JsonProcessingException {
-        Mockito.when(mockRequest.getHeader(UID_INSTANCE_ID_HEADER)).thenReturn(UID_INSTANCE_ID);
+    public void testUIDInstanceIdFromInteg() throws JsonProcessingException {
+        Mockito.when(mockRequest.getHeader(UID_INSTANCE_ID_HEADER)).thenReturn(UID_INSTANCE_ID_FROM_INTEG);
         AuditParams params = new AuditParams();
 
         new Audit("admin").log(mockCtx, params);
@@ -577,6 +579,42 @@ public class AuditTest {
         ObjectMapper mapper = new ObjectMapper();
         JsonNode jsonNode = mapper.readTree(jsonLog);
 
-        assertThat(jsonNode.get("uid_instance_id").asText()).isEqualTo(UID_INSTANCE_ID);
+        assertThat(jsonNode.get("uid_instance_id").asText()).isEqualTo(UID_INSTANCE_ID_FROM_INTEG);
+    }
+
+    @Test
+    public void testUIDInstanceIdFromProd() throws JsonProcessingException {
+        Mockito.when(mockRequest.getHeader(UID_INSTANCE_ID_HEADER)).thenReturn(UID_INSTANCE_ID_FROM_PROD);
+        AuditParams params = new AuditParams();
+
+        new Audit("admin").log(mockCtx, params);
+
+
+        Optional<ILoggingEvent> maybeEvent = listAppender.list.stream()
+                .filter(event -> event.getFormattedMessage().contains("uid_instance_id"))
+                .findFirst();
+        String jsonLog = maybeEvent.get().getFormattedMessage();
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonNode = mapper.readTree(jsonLog);
+
+        assertThat(jsonNode.get("uid_instance_id").asText()).isEqualTo(UID_INSTANCE_ID_FROM_PROD);
+    }
+
+    @Test
+    public void testUIDInstanceIdFromAWS() throws JsonProcessingException {
+        Mockito.when(mockRequest.getHeader(UID_INSTANCE_ID_HEADER)).thenReturn(UID_INSTANCE_ID_FROM_AWS);
+        AuditParams params = new AuditParams();
+
+        new Audit("admin").log(mockCtx, params);
+
+
+        Optional<ILoggingEvent> maybeEvent = listAppender.list.stream()
+                .filter(event -> event.getFormattedMessage().contains("uid_instance_id"))
+                .findFirst();
+        String jsonLog = maybeEvent.get().getFormattedMessage();
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonNode = mapper.readTree(jsonLog);
+
+        assertThat(jsonNode.get("uid_instance_id").asText()).isEqualTo(UID_INSTANCE_ID_FROM_AWS);
     }
 }

--- a/src/test/java/com/uid2/shared/audit/AuditTest.java
+++ b/src/test/java/com/uid2/shared/audit/AuditTest.java
@@ -459,10 +459,10 @@ public class AuditTest {
                 .map(ILoggingEvent::getFormattedMessage)
                 .toList();
 
-        assertThat(messages).anyMatch(msg -> msg.contains(MALFORMED_ID));
+        assertThat(messages).noneMatch(msg -> msg.contains(MALFORMED_ID));
 
         boolean errorLogged = listAppender.list.stream()
-                .anyMatch(event -> event.getLevel() == Level.ERROR && event.getFormattedMessage().contains("Malformed trace_id found in the audit log. Malformed uid_trace_id found in the audit log."));
+                .anyMatch(event -> event.getLevel() == Level.ERROR && event.getFormattedMessage().contains("Malformed trace_id found in the audit log.") && event.getFormattedMessage().contains("Malformed uid_trace_id found in the audit log."));
 
         assertThat(errorLogged).isTrue();
     }

--- a/src/test/java/com/uid2/shared/audit/AuditTest.java
+++ b/src/test/java/com/uid2/shared/audit/AuditTest.java
@@ -48,7 +48,7 @@ public class AuditTest {
     private String UID_INSTANCE_ID_FROM_INTEG = "uid2-integ-use2-operator-dfb4bd68d-v9p6t-a2cf5882f000d7b2";
     private String UID_INSTANCE_ID_FROM_PROD = "uid2-prod-use2-operator-6bb87b7fd-n4smk-90527e73fbffa91c";
     private String UID_INSTANCE_ID_FROM_AWS = "aws-aasdadada-ami-12312311321-v9p6t-a2cf5882f000d7b2";
-    private String MALFORMED_UID_INSTANCE_ID = "uid2-prod-use2-operator-6bb87b7fd-n4smk-90527e73fbffa91c-u";
+    private String MALFORMED_UID_INSTANCE_ID = "uid2-prod-SELECT * FROM usersUID2-O-P-AB12cd34EF-zyX9_abCDEFghijklMNOPQRSTuvwxYZ0123";
 
 
     @BeforeEach
@@ -510,25 +510,6 @@ public class AuditTest {
 
     @Test
     public void testMalformedUIDInstanceId() {
-        Mockito.when(mockRequest.getHeader(UID_INSTANCE_ID_HEADER)).thenReturn(TRACE_ID);
-        AuditParams params = new AuditParams();
-
-        new Audit("admin").log(mockCtx, params);
-
-        List<String> messages = listAppender.list.stream()
-                .map(ILoggingEvent::getFormattedMessage)
-                .toList();
-
-        assertThat(messages).noneMatch(msg -> msg.contains(TRACE_ID));
-
-        boolean errorLogged = listAppender.list.stream()
-                .anyMatch(event -> event.getLevel() == Level.ERROR && event.getFormattedMessage().contains("Malformed uid_instance_id found in the audit log. "));
-
-        assertThat(errorLogged).isTrue();
-    }
-
-    @Test
-    public void testAnotherMalformedUIDInstanceId() {
         Mockito.when(mockRequest.getHeader(UID_INSTANCE_ID_HEADER)).thenReturn(MALFORMED_UID_INSTANCE_ID);
         AuditParams params = new AuditParams();
 
@@ -547,7 +528,7 @@ public class AuditTest {
     }
 
     @Test
-    public void testMalformedUIDInstanceIdNull() throws JsonProcessingException {
+    public void testUIDInstanceIdNull() throws JsonProcessingException {
         Mockito.when(mockRequest.getHeader(UID_INSTANCE_ID_HEADER)).thenReturn(null);
         AuditParams params = new AuditParams();
 

--- a/src/test/java/com/uid2/shared/audit/AuditTest.java
+++ b/src/test/java/com/uid2/shared/audit/AuditTest.java
@@ -43,12 +43,11 @@ public class AuditTest {
     private String SQL_STATEMENT = "SELECT * FROM users WHERE username = '' OR '1'='1'";
     private String TRACE_ID = "Root=1-6825017b-2321f2302b5ea904340c1cff";
     private String UID_TRACE_ID = "Root=1-6825017b-2321f2302b5ea904340c1cfa";
-    private String MALFORMED_TRACE_ID = "Root=1-6825017b-2321f2302b5ea904df340c1ckgg";
     private String AMZN_TRACE_ID_HEADER = "X-Amzn-Trace-Id";
     private String UID_INSTANCE_ID_FROM_INTEG = "uid2-integ-use2-operator-dfb4bd68d-v9p6t-a2cf5882f000d7b2";
     private String UID_INSTANCE_ID_FROM_PROD = "uid2-prod-use2-operator-6bb87b7fd-n4smk-90527e73fbffa91c";
     private String UID_INSTANCE_ID_FROM_AWS = "aws-aasdadada-ami-12312311321-v9p6t-a2cf5882f000d7b2";
-    private String MALFORMED_UID_INSTANCE_ID = "uid2-prod-SELECT * FROM usersUID2-O-P-AB12cd34EF-zyX9_abCDEFghijklMNOPQRSTuvwxYZ0123";
+    private String MALFORMED_ID = "uid2-prod-SELECT * FROM usersUID2-O-P-AB12cd34EF-zyX9_abCDEFghijklMNOPQRSTuvwxYZ0123";
 
 
     @BeforeEach
@@ -451,7 +450,7 @@ public class AuditTest {
 
     @Test
     public void testMalformedTraceId() {
-        Mockito.when(mockRequest.getHeader(AMZN_TRACE_ID_HEADER)).thenReturn(MALFORMED_TRACE_ID);
+        Mockito.when(mockRequest.getHeader(AMZN_TRACE_ID_HEADER)).thenReturn(MALFORMED_ID);
         AuditParams params = new AuditParams();
 
         new Audit("admin").log(mockCtx, params);
@@ -460,7 +459,7 @@ public class AuditTest {
                 .map(ILoggingEvent::getFormattedMessage)
                 .toList();
 
-        assertThat(messages).anyMatch(msg -> msg.contains(MALFORMED_TRACE_ID));
+        assertThat(messages).anyMatch(msg -> msg.contains(MALFORMED_ID));
 
         boolean errorLogged = listAppender.list.stream()
                 .anyMatch(event -> event.getLevel() == Level.ERROR && event.getFormattedMessage().contains("Malformed trace_id found in the audit log. Malformed uid_trace_id found in the audit log."));
@@ -490,7 +489,7 @@ public class AuditTest {
     @Test
     public void testMalformedUIDTraceId() {
         Mockito.when(mockRequest.getHeader(AMZN_TRACE_ID_HEADER)).thenReturn(TRACE_ID);
-        Mockito.when(mockRequest.getHeader(UID_TRACE_ID_HEADER)).thenReturn(MALFORMED_TRACE_ID);
+        Mockito.when(mockRequest.getHeader(UID_TRACE_ID_HEADER)).thenReturn(MALFORMED_ID);
         AuditParams params = new AuditParams();
 
         new Audit("admin").log(mockCtx, params);
@@ -510,7 +509,7 @@ public class AuditTest {
 
     @Test
     public void testMalformedUIDInstanceId() {
-        Mockito.when(mockRequest.getHeader(UID_INSTANCE_ID_HEADER)).thenReturn(MALFORMED_UID_INSTANCE_ID);
+        Mockito.when(mockRequest.getHeader(UID_INSTANCE_ID_HEADER)).thenReturn(MALFORMED_ID);
         AuditParams params = new AuditParams();
 
         new Audit("admin").log(mockCtx, params);


### PR DESCRIPTION
Redact secrets and check spoofed values for audit log fields: traceId, uidInstanceId, uidTraceId, actor, queryParams and requestBody.
1. traceId and uidInstanceId: validate X_Amzn_Trace_Id pattern
2. uidInstanceId: validate suffix is 1 to 16 lowercase hex digits
3. actor, queryParams and requestBody: filter out secret, SQL statement, and truncate the length.