### PR TITLE
Add key name in the audit log error message

### DIFF
--- a/src/main/java/com/uid2/shared/audit/Audit.java
+++ b/src/main/java/com/uid2/shared/audit/Audit.java
@@ -95,8 +95,8 @@ public class Audit {
             for (String key : jsonObject.fieldNames()) {
                 String val = jsonObject.getString(key);
 
-                boolean containsNoSecret = validateNoSecrets(key, propertyName) && validateNoSecrets(val, propertyName);
-                boolean containsNoSQL = validateNoSQL(key, propertyName) && validateNoSQL(val, propertyName);
+                boolean containsNoSecret = validateNoSecrets(val, String.format("%s.%s", propertyName, key));
+                boolean containsNoSQL = validateNoSQL(val, String.format("%s.%s", propertyName, key));
 
                 if (!(containsNoSecret && containsNoSQL)) {
                     keysToRemove.add(key);
@@ -128,7 +128,7 @@ public class Audit {
                         newJsonArray.add(object);
                     }
                 } else {
-                    toJsonValidationErrorMessageBuilder.append("The request body is a JSON array, but one of its elements is not a JSON object.");
+                    toJsonValidationErrorMessageBuilder.append(String.format("The request body is a JSON array, but one of its elements is not a JSON object: %s. ", object.toString()));
                 }
             }
 
@@ -152,7 +152,7 @@ public class Audit {
                     JsonArray jsonArray = new JsonArray(mapper.writeValueAsString(root));
                     if (validateJsonArrayParams(jsonArray, "request_body")) sanitizedRequestBody = jsonArray.toString();
                 } else {
-                    toJsonValidationErrorMessageBuilder.append("The request body of audit log is not a JSON object or array. ");
+                    toJsonValidationErrorMessageBuilder.append(String.format("The request body of audit log is not a JSON object or array: %s. ", requestBody));
                 }
             } catch (Exception e) {
                 toJsonValidationErrorMessageBuilder.append("The request body of audit log is Invalid JSON: ").append(e.getMessage());


### PR DESCRIPTION
Reduce the aggressiveness of secret redaction. For JSON objects in the form {key: value}, previously we validate both key and value. For debugging purpose and keys are less likely to contain secrets, we now want to validate only the value.  If a secret is detected, log the key name, not the value in the error message.
Same as SQL validation.