### PR TITLE
Made refreshFrom a mandatory field and removed field length check when parsing salt files

### DIFF
--- a/src/main/java/com/uid2/shared/model/SaltEntry.java
+++ b/src/main/java/com/uid2/shared/model/SaltEntry.java
@@ -12,32 +12,32 @@ public record SaltEntry(
         KeyMaterial currentKey,
         KeyMaterial previousKey
 ) {
-//    @Override
-//    public String toString() {
-//        return "SaltEntry{" +
-//                "id=" + id +
-//                ", hashedId='" + hashedId + '\'' +
-//                ", lastUpdated=" + lastUpdated +
-//                ", currentSalt=<REDACTED>" +
-//                ", refreshFrom=" + refreshFrom +
-//                ", previousSalt=<REDACTED>" +
-//                ", currentKey=" + currentKey +
-//                ", previousKey=" + previousKey +
-//                '}';
-//    }
+    @Override
+    public String toString() {
+        return "SaltEntry{" +
+                "id=" + id +
+                ", hashedId='" + hashedId + '\'' +
+                ", lastUpdated=" + lastUpdated +
+                ", currentSalt=<REDACTED>" +
+                ", refreshFrom=" + refreshFrom +
+                ", previousSalt=<REDACTED>" +
+                ", currentKey=" + currentKey +
+                ", previousKey=" + previousKey +
+                '}';
+    }
 
     public record KeyMaterial(
             int id,
             String key,
             String salt
     ) {
-//        @Override
-//        public String toString() {
-//            return "KeyMaterial{" +
-//                    "id=" + id +
-//                    ", key=<REDACTED>" +
-//                    ", currentSalt=<REDACTED>" +
-//                    '}';
-//        }
+        @Override
+        public String toString() {
+            return "KeyMaterial{" +
+                    "id=" + id +
+                    ", key=<REDACTED>" +
+                    ", currentSalt=<REDACTED>" +
+                    '}';
+        }
     }
 }

--- a/src/main/java/com/uid2/shared/model/SaltEntry.java
+++ b/src/main/java/com/uid2/shared/model/SaltEntry.java
@@ -12,32 +12,32 @@ public record SaltEntry(
         KeyMaterial currentKey,
         KeyMaterial previousKey
 ) {
-    @Override
-    public String toString() {
-        return "SaltEntry{" +
-                "id=" + id +
-                ", hashedId='" + hashedId + '\'' +
-                ", lastUpdated=" + lastUpdated +
-                ", currentSalt=<REDACTED>" +
-                ", refreshFrom=" + refreshFrom +
-                ", previousSalt=<REDACTED>" +
-                ", currentKey=" + currentKey +
-                ", previousKey=" + previousKey +
-                '}';
-    }
+//    @Override
+//    public String toString() {
+//        return "SaltEntry{" +
+//                "id=" + id +
+//                ", hashedId='" + hashedId + '\'' +
+//                ", lastUpdated=" + lastUpdated +
+//                ", currentSalt=<REDACTED>" +
+//                ", refreshFrom=" + refreshFrom +
+//                ", previousSalt=<REDACTED>" +
+//                ", currentKey=" + currentKey +
+//                ", previousKey=" + previousKey +
+//                '}';
+//    }
 
     public record KeyMaterial(
             int id,
             String key,
             String salt
     ) {
-        @Override
-        public String toString() {
-            return "KeyMaterial{" +
-                    "id=" + id +
-                    ", key=<REDACTED>" +
-                    ", currentSalt=<REDACTED>" +
-                    '}';
-        }
+//        @Override
+//        public String toString() {
+//            return "KeyMaterial{" +
+//                    "id=" + id +
+//                    ", key=<REDACTED>" +
+//                    ", currentSalt=<REDACTED>" +
+//                    '}';
+//        }
     }
 }

--- a/src/main/java/com/uid2/shared/store/salt/SaltFileParser.java
+++ b/src/main/java/com/uid2/shared/store/salt/SaltFileParser.java
@@ -39,11 +39,11 @@ public class SaltFileParser {
             // AU, 2025/07/28
             SaltEntry.KeyMaterial currentKey = null;
             SaltEntry.KeyMaterial previousKey = null;
-            if (fields.length > 7 && trimToNull(fields[5]) != null && trimToNull(fields[6]) != null) {
+            if (trimToNull(fields[5]) != null && trimToNull(fields[6]) != null) {
                 currentKey = new SaltEntry.KeyMaterial(Integer.parseInt(fields[5]), fields[6], fields[7]);
             }
 
-            if (fields.length > 10 && trimToNull(fields[8]) != null && trimToNull(fields[9]) != null) {
+            if (trimToNull(fields[8]) != null && trimToNull(fields[9]) != null) {
                 previousKey = new SaltEntry.KeyMaterial(Integer.parseInt(fields[8]), fields[9], fields[10]);
             }
 

--- a/src/main/java/com/uid2/shared/store/salt/SaltFileParser.java
+++ b/src/main/java/com/uid2/shared/store/salt/SaltFileParser.java
@@ -27,23 +27,23 @@ public class SaltFileParser {
 
     private SaltEntry parseLine(String line, int lineNumber) {
         try {
-            final String[] fields = line.split(",");
+            final String[] fields = line.split(",", -1);
             final long id = Integer.parseInt(fields[0]);
             final String hashedId = this.idHashingScheme.encode(id);
             final long lastUpdated = Long.parseLong(fields[1]);
             final String salt = fields[2];
             final long refreshFrom = Long.parseLong(fields[3]);
-            final String previousSalt = fields[4];
+            final String previousSalt = trimToNull(fields[4]);
 
             // TODO: The fields below should stop being optional once refreshable UIDs features get rolled out in production. We can remove them one by one as necessary.
             // AU, 2025/07/28
             SaltEntry.KeyMaterial currentKey = null;
             SaltEntry.KeyMaterial previousKey = null;
-            if (fields.length > 7) {
+            if (fields.length > 7 && trimToNull(fields[5]) != null && trimToNull(fields[6]) != null) {
                 currentKey = new SaltEntry.KeyMaterial(Integer.parseInt(fields[5]), fields[6], fields[7]);
             }
 
-            if (fields.length > 10) {
+            if (fields.length > 10 && trimToNull(fields[8]) != null && trimToNull(fields[9]) != null) {
                 previousKey = new SaltEntry.KeyMaterial(Integer.parseInt(fields[8]), fields[9], fields[10]);
             }
 
@@ -53,4 +53,7 @@ public class SaltFileParser {
         }
     }
 
+    private String trimToNull(String s) {
+        return s == null || s.isBlank() ? null : s.trim();
+    }
 }

--- a/src/main/java/com/uid2/shared/store/salt/SaltFileParser.java
+++ b/src/main/java/com/uid2/shared/store/salt/SaltFileParser.java
@@ -32,24 +32,17 @@ public class SaltFileParser {
             final String hashedId = this.idHashingScheme.encode(id);
             final long lastUpdated = Long.parseLong(fields[1]);
             final String salt = fields[2];
+            final long refreshFrom = Long.parseLong(fields[3]);
+            final String previousSalt = fields[4];
 
-            Long refreshFrom = null;
-            String previousSalt = null;
+            // TODO: The fields below should stop being optional once refreshable UIDs features get rolled out in production. We can remove them one by one as necessary.
+            // AU, 2025/07/28
             SaltEntry.KeyMaterial currentKey = null;
             SaltEntry.KeyMaterial previousKey = null;
-
-            // TODO: The fields below should stop being optional once the refresh from, previous salt
-            // and refreshable UIDs features get rolled out in production. We can remove them one by one as necessary.
-            // AU, 2025/04/28
-            if (fields.length > 3) {
-                refreshFrom = Long.parseLong(fields[3]);
-            }
-            if (fields.length > 4) {
-                previousSalt = fields[4];
-            }
             if (fields.length > 7) {
                 currentKey = new SaltEntry.KeyMaterial(Integer.parseInt(fields[5]), fields[6], fields[7]);
             }
+
             if (fields.length > 10) {
                 previousKey = new SaltEntry.KeyMaterial(Integer.parseInt(fields[8]), fields[9], fields[10]);
             }

--- a/src/test/java/com/uid2/shared/store/EncryptedRotatingSaltProviderTest.java
+++ b/src/test/java/com/uid2/shared/store/EncryptedRotatingSaltProviderTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-public class EncryptedRotatingSaltProviderTest {
+class EncryptedRotatingSaltProviderTest {
     @Mock
     private ICloudStorage cloudStorage;
     @Mock
@@ -38,7 +38,7 @@ public class EncryptedRotatingSaltProviderTest {
     private CloudEncryptionKey encryptionKey;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         byte[] keyBytes = new byte[32];
         new Random().nextBytes(keyBytes);
         String base64Key = Base64.getEncoder().encodeToString(keyBytes);
@@ -65,7 +65,7 @@ public class EncryptedRotatingSaltProviderTest {
     }
 
     @Test
-    public void metadataPath() {
+    void metadataPath() {
         EncryptedRotatingSaltProvider saltsProvider = new EncryptedRotatingSaltProvider(
                 cloudStorage, keyProvider, new EncryptedScope(new CloudPath("salts/metadata.json"), 1, true));
 
@@ -73,7 +73,7 @@ public class EncryptedRotatingSaltProviderTest {
     }
 
     @Test
-    public void loadSaltSingleVersion() throws Exception {
+    void loadSaltSingleVersion() throws Exception {
         final String firstLevelSalt = "first_level_salt_value";
         final String idPrefix = "a";
         final String idSecret = "m3yMIcbg9vCaFLJsn4m4PfruZnvAZ72OxmFG5QsGMOw=";
@@ -103,14 +103,14 @@ public class EncryptedRotatingSaltProviderTest {
         final String effectiveTimeString = String.valueOf(generatedTime.getEpochSecond() * 1000L);
         final String refreshFromTimeString = String.valueOf(generatedTime.plus(30, ChronoUnit.DAYS).getEpochSecond() * 1000L);
         final String salts =
-                "1000000," + effectiveTimeString + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeString + ",\n" +
-                        "1000001," + effectiveTimeString + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeString + ",\n" +
-                        "1000002," + effectiveTimeString + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=," + refreshFromTimeString + ",\n" +
-                        "1000003," + effectiveTimeString + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeString + ",\n" +
-                        "1000004," + effectiveTimeString + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeString + ",\n" +
-                        "1000005," + effectiveTimeString + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeString + ",\n" +
-                        "1000006," + effectiveTimeString + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeString + ",\n" +
-                        "1000007," + effectiveTimeString + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeString + ",";
+                "1000000," + effectiveTimeString + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeString + ",,,,,,\n" +
+                        "1000001," + effectiveTimeString + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeString + ",,,,,,\n" +
+                        "1000002," + effectiveTimeString + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=," + refreshFromTimeString + ",,,,,,\n" +
+                        "1000003," + effectiveTimeString + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeString + ",,,,,,\n" +
+                        "1000004," + effectiveTimeString + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeString + ",,,,,,\n" +
+                        "1000005," + effectiveTimeString + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeString + ",,,,,,\n" +
+                        "1000006," + effectiveTimeString + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeString + ",,,,,,\n" +
+                        "1000007," + effectiveTimeString + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeString + ",,,,,,";
 
         when(cloudStorage.download("sites/encrypted/1_public/metadata.json"))
                 .thenReturn(new ByteArrayInputStream(metadataJson.toString().getBytes(StandardCharsets.US_ASCII)));
@@ -130,7 +130,7 @@ public class EncryptedRotatingSaltProviderTest {
     }
 
     @Test
-    public void loadSaltSingleVersion1mil() throws Exception {
+    void loadSaltSingleVersion1mil() throws Exception {
         final String firstLevelSalt = "first_level_salt_value";
         final String idPrefix = "a";
         final String idSecret = "m3yMIcbg9vCaFLJsn4m4PfruZnvAZ72OxmFG5QsGMOw=";
@@ -161,7 +161,7 @@ public class EncryptedRotatingSaltProviderTest {
         final String refreshFromTimeString = String.valueOf(generatedTime.plus(30, ChronoUnit.DAYS).getEpochSecond() * 1000L);
         StringBuilder salts = new StringBuilder();
         for (int i = 0; i < 1000000; i++) {
-            salts.append(i).append(",").append(effectiveTimeString).append(",").append("currentSalt-string").append(",").append(refreshFromTimeString).append(",").append("\n");
+            salts.append(i).append(",").append(effectiveTimeString).append(",").append("currentSalt-string").append(",").append(refreshFromTimeString).append(",,,,,,").append("\n");
         }
 
         when(cloudStorage.download("sites/encrypted/1_public/metadata.json"))
@@ -182,7 +182,7 @@ public class EncryptedRotatingSaltProviderTest {
     }
 
     @Test
-    public void loadSaltMultipleVersions() throws Exception {
+    void loadSaltMultipleVersions() throws Exception {
         final String firstLevelSalt = "first_level_salt_value";
         final String idPrefix = "a";
         final String idSecret = "m3yMIcbg9vCaFLJsn4m4PfruZnvAZ72OxmFG5QsGMOw=";
@@ -225,25 +225,25 @@ public class EncryptedRotatingSaltProviderTest {
         final String refreshFromTimeStringV2 = String.valueOf(generatedTimeV2.plus(60, ChronoUnit.DAYS).getEpochSecond() * 1000L);
 
         final String saltsV1 =
-                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000002," + effectiveTimeStringV1 + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV1 + ",";
+                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000002," + effectiveTimeStringV1 + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV1 + ",,,,,,";
 
         // update key 1000002
         final String saltsV2 =
-                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000002," + effectiveTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=," + refreshFromTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=\n" +
-                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV2 + ",";
+                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000002," + effectiveTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=," + refreshFromTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=,,,,,\n" +
+                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV2 + ",,,,,,";
 
         when(cloudStorage.download("sites/encrypted/1_public/metadata.json"))
                 .thenReturn(new ByteArrayInputStream(metadataJson.toString().getBytes(StandardCharsets.US_ASCII)));
@@ -267,10 +267,10 @@ public class EncryptedRotatingSaltProviderTest {
     }
 
     @Test
-    public void loadSaltMultipleVersionsExpired() throws Exception {
-        final String FIRST_LEVEL_SALT = "first_level_salt_value";
-        final String ID_PREFIX = "a";
-        final String ID_SECRET = "m3yMIcbg9vCaFLJsn4m4PfruZnvAZ72OxmFG5QsGMOw=";
+    void loadSaltMultipleVersionsExpired() throws Exception {
+        final String firstLevelSalt = "first_level_salt_value";
+        final String idPrefix = "a";
+        final String idSecret = "m3yMIcbg9vCaFLJsn4m4PfruZnvAZ72OxmFG5QsGMOw=";
 
         final Instant generatedTimeV1 = Instant.now().minus(3, ChronoUnit.DAYS);
         final Instant expireTimeV1 = Instant.now().minus(2, ChronoUnit.DAYS);
@@ -281,9 +281,9 @@ public class EncryptedRotatingSaltProviderTest {
         {
             metadataJson.put("version", 2);
             metadataJson.put("generated", generatedTimeV1.getEpochSecond() * 1000L);
-            metadataJson.put("first_level", FIRST_LEVEL_SALT);
-            metadataJson.put("id_prefix", ID_PREFIX);
-            metadataJson.put("id_secret", ID_SECRET);
+            metadataJson.put("first_level", firstLevelSalt);
+            metadataJson.put("id_prefix", idPrefix);
+            metadataJson.put("id_secret", idSecret);
             final JsonArray saltsRefList = new JsonArray();
             {
                 final JsonObject saltsRef = new JsonObject();
@@ -310,25 +310,25 @@ public class EncryptedRotatingSaltProviderTest {
         final String refreshFromTimeStringV2 = String.valueOf(generatedTimeV2.plus(60, ChronoUnit.DAYS).getEpochSecond() * 1000L);
 
         final String saltsV1 =
-                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000002," + effectiveTimeStringV1 + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV1 + ",";
+                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000002," + effectiveTimeStringV1 + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV1 + ",,,,,,";
 
         // update key 1000002
         final String saltsV2 =
-                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000002," + effectiveTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=," + refreshFromTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=\n" +
-                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV2 + ",";
+                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000002," + effectiveTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=," + refreshFromTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=,,,,,\n" +
+                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV2 + ",,,,,,";
 
         when(cloudStorage.download("sites/encrypted/1_public/metadata.json"))
                 .thenReturn(new ByteArrayInputStream(metadataJson.toString().getBytes(StandardCharsets.US_ASCII)));
@@ -345,7 +345,7 @@ public class EncryptedRotatingSaltProviderTest {
         assertEquals(2, saltsProvider.getVersion(loadedMetadata));
 
         final ISaltProvider.ISaltSnapshot snapshot = saltsProvider.getSnapshot(Instant.now());
-        assertEquals(FIRST_LEVEL_SALT, snapshot.getFirstLevelSalt());
+        assertEquals(firstLevelSalt, snapshot.getFirstLevelSalt());
         assertTrue(snapshot.getModifiedSince(Instant.now().minus(1, ChronoUnit.HOURS)).isEmpty());
         assertEquals(1, snapshot.getModifiedSince(Instant.now().minus(49, ChronoUnit.HOURS)).size());
         assertEquals(1000002, snapshot.getModifiedSince(Instant.now().minus(49, ChronoUnit.HOURS)).getFirst().id());

--- a/src/test/java/com/uid2/shared/store/EncryptedRotatingSaltProviderTest.java
+++ b/src/test/java/com/uid2/shared/store/EncryptedRotatingSaltProviderTest.java
@@ -74,9 +74,9 @@ public class EncryptedRotatingSaltProviderTest {
 
     @Test
     public void loadSaltSingleVersion() throws Exception {
-        final String FIRST_LEVEL_SALT = "first_level_salt_value";
-        final String ID_PREFIX = "a";
-        final String ID_SECRET = "m3yMIcbg9vCaFLJsn4m4PfruZnvAZ72OxmFG5QsGMOw=";
+        final String firstLevelSalt = "first_level_salt_value";
+        final String idPrefix = "a";
+        final String idSecret = "m3yMIcbg9vCaFLJsn4m4PfruZnvAZ72OxmFG5QsGMOw=";
 
         final Instant generatedTime = Instant.now().minus(1, ChronoUnit.DAYS);
         final Instant expireTime = Instant.now().plus(365, ChronoUnit.DAYS);
@@ -85,9 +85,9 @@ public class EncryptedRotatingSaltProviderTest {
         {
             metadataJson.put("version", 2);
             metadataJson.put("generated", generatedTime.getEpochSecond() * 1000L);
-            metadataJson.put("first_level", FIRST_LEVEL_SALT);
-            metadataJson.put("id_prefix", ID_PREFIX);
-            metadataJson.put("id_secret", ID_SECRET);
+            metadataJson.put("first_level", firstLevelSalt);
+            metadataJson.put("id_prefix", idPrefix);
+            metadataJson.put("id_secret", idSecret);
             final JsonArray saltsRefList = new JsonArray();
             {
                 final JsonObject saltsRef = new JsonObject();
@@ -101,15 +101,16 @@ public class EncryptedRotatingSaltProviderTest {
         }
 
         final String effectiveTimeString = String.valueOf(generatedTime.getEpochSecond() * 1000L);
+        final String refreshFromTimeString = String.valueOf(generatedTime.plus(30, ChronoUnit.DAYS).getEpochSecond() * 1000L);
         final String salts =
-                "1000000," + effectiveTimeString + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=\n" +
-                "1000001," + effectiveTimeString + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=\n" +
-                "1000002," + effectiveTimeString + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=\n" +
-                "1000003," + effectiveTimeString + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=\n" +
-                "1000004," + effectiveTimeString + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=\n" +
-                "1000005," + effectiveTimeString + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=\n" +
-                "1000006," + effectiveTimeString + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=\n" +
-                "1000007," + effectiveTimeString + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=";
+                "1000000," + effectiveTimeString + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeString + ",\n" +
+                        "1000001," + effectiveTimeString + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeString + ",\n" +
+                        "1000002," + effectiveTimeString + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=," + refreshFromTimeString + ",\n" +
+                        "1000003," + effectiveTimeString + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeString + ",\n" +
+                        "1000004," + effectiveTimeString + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeString + ",\n" +
+                        "1000005," + effectiveTimeString + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeString + ",\n" +
+                        "1000006," + effectiveTimeString + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeString + ",\n" +
+                        "1000007," + effectiveTimeString + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeString + ",";
 
         when(cloudStorage.download("sites/encrypted/1_public/metadata.json"))
                 .thenReturn(new ByteArrayInputStream(metadataJson.toString().getBytes(StandardCharsets.US_ASCII)));
@@ -124,15 +125,15 @@ public class EncryptedRotatingSaltProviderTest {
         assertEquals(2, saltsProvider.getVersion(loadedMetadata));
 
         final ISaltProvider.ISaltSnapshot snapshot = saltsProvider.getSnapshot(Instant.now());
-        assertEquals(FIRST_LEVEL_SALT, snapshot.getFirstLevelSalt());
+        assertEquals(firstLevelSalt, snapshot.getFirstLevelSalt());
         assertTrue(snapshot.getModifiedSince(Instant.now().minus(1, ChronoUnit.HOURS)).isEmpty());
     }
 
     @Test
     public void loadSaltSingleVersion1mil() throws Exception {
-        final String FIRST_LEVEL_SALT = "first_level_salt_value";
-        final String ID_PREFIX = "a";
-        final String ID_SECRET = "m3yMIcbg9vCaFLJsn4m4PfruZnvAZ72OxmFG5QsGMOw=";
+        final String firstLevelSalt = "first_level_salt_value";
+        final String idPrefix = "a";
+        final String idSecret = "m3yMIcbg9vCaFLJsn4m4PfruZnvAZ72OxmFG5QsGMOw=";
 
         final Instant generatedTime = Instant.now().minus(1, ChronoUnit.DAYS);
         final Instant expireTime = Instant.now().plus(365, ChronoUnit.DAYS);
@@ -141,9 +142,9 @@ public class EncryptedRotatingSaltProviderTest {
         {
             metadataJson.put("version", 2);
             metadataJson.put("generated", generatedTime.getEpochSecond() * 1000L);
-            metadataJson.put("first_level", FIRST_LEVEL_SALT);
-            metadataJson.put("id_prefix", ID_PREFIX);
-            metadataJson.put("id_secret", ID_SECRET);
+            metadataJson.put("first_level", firstLevelSalt);
+            metadataJson.put("id_prefix", idPrefix);
+            metadataJson.put("id_secret", idSecret);
             final JsonArray saltsRefList = new JsonArray();
             {
                 final JsonObject saltsRef = new JsonObject();
@@ -157,9 +158,10 @@ public class EncryptedRotatingSaltProviderTest {
         }
 
         final String effectiveTimeString = String.valueOf(generatedTime.getEpochSecond() * 1000L);
+        final String refreshFromTimeString = String.valueOf(generatedTime.plus(30, ChronoUnit.DAYS).getEpochSecond() * 1000L);
         StringBuilder salts = new StringBuilder();
         for (int i = 0; i < 1000000; i++) {
-            salts.append(i).append(",").append(effectiveTimeString).append(",").append("currentSalt-string").append("\n");
+            salts.append(i).append(",").append(effectiveTimeString).append(",").append("currentSalt-string").append(",").append(refreshFromTimeString).append(",").append("\n");
         }
 
         when(cloudStorage.download("sites/encrypted/1_public/metadata.json"))
@@ -175,15 +177,15 @@ public class EncryptedRotatingSaltProviderTest {
         assertEquals(2, saltsProvider.getVersion(loadedMetadata));
 
         final ISaltProvider.ISaltSnapshot snapshot = saltsProvider.getSnapshot(Instant.now());
-        assertEquals(FIRST_LEVEL_SALT, snapshot.getFirstLevelSalt());
+        assertEquals(firstLevelSalt, snapshot.getFirstLevelSalt());
         assertTrue(snapshot.getModifiedSince(Instant.now().minus(1, ChronoUnit.HOURS)).isEmpty());
     }
 
     @Test
     public void loadSaltMultipleVersions() throws Exception {
-        final String FIRST_LEVEL_SALT = "first_level_salt_value";
-        final String ID_PREFIX = "a";
-        final String ID_SECRET = "m3yMIcbg9vCaFLJsn4m4PfruZnvAZ72OxmFG5QsGMOw=";
+        final String firstLevelSalt = "first_level_salt_value";
+        final String idPrefix = "a";
+        final String idSecret = "m3yMIcbg9vCaFLJsn4m4PfruZnvAZ72OxmFG5QsGMOw=";
 
         final Instant generatedTimeV1 = Instant.now().minus(2, ChronoUnit.DAYS);
         final Instant expireTimeV1 = Instant.now().plus(365, ChronoUnit.DAYS);
@@ -194,9 +196,9 @@ public class EncryptedRotatingSaltProviderTest {
         {
             metadataJson.put("version", 2);
             metadataJson.put("generated", generatedTimeV1.getEpochSecond() * 1000L);
-            metadataJson.put("first_level", FIRST_LEVEL_SALT);
-            metadataJson.put("id_prefix", ID_PREFIX);
-            metadataJson.put("id_secret", ID_SECRET);
+            metadataJson.put("first_level", firstLevelSalt);
+            metadataJson.put("id_prefix", idPrefix);
+            metadataJson.put("id_secret", idSecret);
             final JsonArray saltsRefList = new JsonArray();
             {
                 final JsonObject saltsRef = new JsonObject();
@@ -218,27 +220,30 @@ public class EncryptedRotatingSaltProviderTest {
         }
 
         final String effectiveTimeStringV1 = String.valueOf(generatedTimeV1.getEpochSecond() * 1000L);
+        final String refreshFromTimeStringV1 = String.valueOf(generatedTimeV1.plus(30, ChronoUnit.DAYS).getEpochSecond() * 1000L);
+        final String effectiveTimeStringV2 = String.valueOf(generatedTimeV2.getEpochSecond() * 1000L);
+        final String refreshFromTimeStringV2 = String.valueOf(generatedTimeV2.plus(60, ChronoUnit.DAYS).getEpochSecond() * 1000L);
+
         final String saltsV1 =
-                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=\n" +
-                "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=\n" +
-                "1000002," + effectiveTimeStringV1 + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=\n" +
-                "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=\n" +
-                "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=\n" +
-                "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=\n" +
-                "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=\n" +
-                "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=";
+                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000002," + effectiveTimeStringV1 + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV1 + ",";
 
         // update key 1000002
-        final String effectiveTimeStringV2 = String.valueOf(generatedTimeV2.getEpochSecond() * 1000L);
         final String saltsV2 =
-                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=\n" +
-                "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=\n" +
-                "1000002," + effectiveTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=\n" +
-                "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=\n" +
-                "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=\n" +
-                "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=\n" +
-                "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=\n" +
-                "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=";
+                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000002," + effectiveTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=," + refreshFromTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=\n" +
+                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV2 + ",";
 
         when(cloudStorage.download("sites/encrypted/1_public/metadata.json"))
                 .thenReturn(new ByteArrayInputStream(metadataJson.toString().getBytes(StandardCharsets.US_ASCII)));
@@ -255,7 +260,7 @@ public class EncryptedRotatingSaltProviderTest {
         assertEquals(2, saltsProvider.getVersion(loadedMetadata));
 
         final ISaltProvider.ISaltSnapshot snapshot = saltsProvider.getSnapshot(Instant.now());
-        assertEquals(FIRST_LEVEL_SALT, snapshot.getFirstLevelSalt());
+        assertEquals(firstLevelSalt, snapshot.getFirstLevelSalt());
         assertTrue(snapshot.getModifiedSince(Instant.now().minus(1, ChronoUnit.HOURS)).isEmpty());
         assertEquals(1, snapshot.getModifiedSince(Instant.now().minus(30, ChronoUnit.HOURS)).size());
         assertEquals(1000002, snapshot.getModifiedSince(Instant.now().minus(30, ChronoUnit.HOURS)).getFirst().id());
@@ -300,27 +305,30 @@ public class EncryptedRotatingSaltProviderTest {
         }
 
         final String effectiveTimeStringV1 = String.valueOf(generatedTimeV1.getEpochSecond() * 1000L);
+        final String refreshFromTimeStringV1 = String.valueOf(generatedTimeV1.plus(30, ChronoUnit.DAYS).getEpochSecond() * 1000L);
+        final String effectiveTimeStringV2 = String.valueOf(generatedTimeV2.getEpochSecond() * 1000L);
+        final String refreshFromTimeStringV2 = String.valueOf(generatedTimeV2.plus(60, ChronoUnit.DAYS).getEpochSecond() * 1000L);
+
         final String saltsV1 =
-                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=\n" +
-                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=\n" +
-                        "1000002," + effectiveTimeStringV1 + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=\n" +
-                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=\n" +
-                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=\n" +
-                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=\n" +
-                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=\n" +
-                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=";
+                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000002," + effectiveTimeStringV1 + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV1 + ",";
 
         // update key 1000002
-        final String effectiveTimeStringV2 = String.valueOf(generatedTimeV2.getEpochSecond() * 1000L);
         final String saltsV2 =
-                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=\n" +
-                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=\n" +
-                        "1000002," + effectiveTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=\n" +
-                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=\n" +
-                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=\n" +
-                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=\n" +
-                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=\n" +
-                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=";
+                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000002," + effectiveTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=," + refreshFromTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=\n" +
+                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV2 + ",";
 
         when(cloudStorage.download("sites/encrypted/1_public/metadata.json"))
                 .thenReturn(new ByteArrayInputStream(metadataJson.toString().getBytes(StandardCharsets.US_ASCII)));

--- a/src/test/java/com/uid2/shared/store/RotatingSaltProviderTest.java
+++ b/src/test/java/com/uid2/shared/store/RotatingSaltProviderTest.java
@@ -26,9 +26,9 @@ public class RotatingSaltProviderTest {
 
     @Test
     public void loadSaltSingleVersion() throws Exception {
-        final String FIRST_LEVEL_SALT = "first_level_salt_value";
-        final String ID_PREFIX = "a";
-        final String ID_SECRET = "m3yMIcbg9vCaFLJsn4m4PfruZnvAZ72OxmFG5QsGMOw=";
+        final String firstLevelSalt = "first_level_salt_value";
+        final String idPrefix = "a";
+        final String idSecret = "m3yMIcbg9vCaFLJsn4m4PfruZnvAZ72OxmFG5QsGMOw=";
 
         final Instant generatedTime = Instant.now().minus(1, ChronoUnit.DAYS);
         final Instant expireTime = Instant.now().plus(365, ChronoUnit.DAYS);
@@ -37,9 +37,9 @@ public class RotatingSaltProviderTest {
         {
             metadataJson.put("version", 2);
             metadataJson.put("generated", generatedTime.getEpochSecond() * 1000L);
-            metadataJson.put("first_level", FIRST_LEVEL_SALT);
-            metadataJson.put("id_prefix", ID_PREFIX);
-            metadataJson.put("id_secret", ID_SECRET);
+            metadataJson.put("first_level", firstLevelSalt);
+            metadataJson.put("id_prefix", idPrefix);
+            metadataJson.put("id_secret", idSecret);
             final JsonArray saltsRefList = new JsonArray();
             {
                 final JsonObject saltsRef = new JsonObject();
@@ -53,15 +53,16 @@ public class RotatingSaltProviderTest {
         }
 
         final String effectiveTimeString = String.valueOf(generatedTime.getEpochSecond() * 1000L);
+        final String refreshFromTimeString = String.valueOf(generatedTime.plus(30, ChronoUnit.DAYS).getEpochSecond() * 1000L);
         final String salts =
-                "1000000," + effectiveTimeString + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=\n" +
-                        "1000001," + effectiveTimeString + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=\n" +
-                        "1000002," + effectiveTimeString + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=\n" +
-                        "1000003," + effectiveTimeString + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=\n" +
-                        "1000004," + effectiveTimeString + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=\n" +
-                        "1000005," + effectiveTimeString + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=\n" +
-                        "1000006," + effectiveTimeString + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=\n" +
-                        "1000007," + effectiveTimeString + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=";
+                "1000000," + effectiveTimeString + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeString + ",\n" +
+                        "1000001," + effectiveTimeString + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeString + ",\n" +
+                        "1000002," + effectiveTimeString + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=," + refreshFromTimeString + ",\n" +
+                        "1000003," + effectiveTimeString + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeString + ",\n" +
+                        "1000004," + effectiveTimeString + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeString + ",\n" +
+                        "1000005," + effectiveTimeString + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeString + ",\n" +
+                        "1000006," + effectiveTimeString + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeString + ",\n" +
+                        "1000007," + effectiveTimeString + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeString + ",";
 
         when(cloudStorage.download("metadata"))
                 .thenReturn(new ByteArrayInputStream(metadataJson.toString().getBytes(StandardCharsets.US_ASCII)));
@@ -76,15 +77,15 @@ public class RotatingSaltProviderTest {
         assertEquals(2, saltsProvider.getVersion(loadedMetadata));
 
         final ISaltProvider.ISaltSnapshot snapshot = saltsProvider.getSnapshot(Instant.now());
-        assertEquals(FIRST_LEVEL_SALT, snapshot.getFirstLevelSalt());
+        assertEquals(firstLevelSalt, snapshot.getFirstLevelSalt());
         assertTrue(snapshot.getModifiedSince(Instant.now().minus(1, ChronoUnit.HOURS)).isEmpty());
     }
 
     @Test
     public void loadSaltMultipleVersions() throws Exception {
-        final String FIRST_LEVEL_SALT = "first_level_salt_value";
-        final String ID_PREFIX = "a";
-        final String ID_SECRET = "m3yMIcbg9vCaFLJsn4m4PfruZnvAZ72OxmFG5QsGMOw=";
+        final String firstLevelSalt = "first_level_salt_value";
+        final String idPrefix = "a";
+        final String idSecret = "m3yMIcbg9vCaFLJsn4m4PfruZnvAZ72OxmFG5QsGMOw=";
 
         final Instant generatedTimeV1 = Instant.now().minus(2, ChronoUnit.DAYS);
         final Instant expireTimeV1 = Instant.now().plus(365, ChronoUnit.DAYS);
@@ -95,9 +96,9 @@ public class RotatingSaltProviderTest {
         {
             metadataJson.put("version", 2);
             metadataJson.put("generated", generatedTimeV1.getEpochSecond() * 1000L);
-            metadataJson.put("first_level", FIRST_LEVEL_SALT);
-            metadataJson.put("id_prefix", ID_PREFIX);
-            metadataJson.put("id_secret", ID_SECRET);
+            metadataJson.put("first_level", firstLevelSalt);
+            metadataJson.put("id_prefix", idPrefix);
+            metadataJson.put("id_secret", idSecret);
             final JsonArray saltsRefList = new JsonArray();
             {
                 final JsonObject saltsRef = new JsonObject();
@@ -119,27 +120,30 @@ public class RotatingSaltProviderTest {
         }
 
         final String effectiveTimeStringV1 = String.valueOf(generatedTimeV1.getEpochSecond() * 1000L);
+        final String refreshFromTimeStringV1 = String.valueOf(generatedTimeV1.plus(30, ChronoUnit.DAYS).getEpochSecond() * 1000L);
+        final String effectiveTimeStringV2 = String.valueOf(generatedTimeV2.getEpochSecond() * 1000L);
+        final String refreshFromTimeStringV2 = String.valueOf(generatedTimeV2.plus(60, ChronoUnit.DAYS).getEpochSecond() * 1000L);
+
         final String saltsV1 =
-                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=\n" +
-                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=\n" +
-                        "1000002," + effectiveTimeStringV1 + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=\n" +
-                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=\n" +
-                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=\n" +
-                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=\n" +
-                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=\n" +
-                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=";
+                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000002," + effectiveTimeStringV1 + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV1 + ",";
 
         // update key 1000002
-        final String effectiveTimeStringV2 = String.valueOf(generatedTimeV2.getEpochSecond() * 1000L);
         final String saltsV2 =
-                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=\n" +
-                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=\n" +
-                        "1000002," + effectiveTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=\n" +
-                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=\n" +
-                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=\n" +
-                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=\n" +
-                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=\n" +
-                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=";
+                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000002," + effectiveTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=," + refreshFromTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=\n" +
+                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV2 + ",";
 
         when(cloudStorage.download("metadata"))
                 .thenReturn(new ByteArrayInputStream(metadataJson.toString().getBytes(StandardCharsets.US_ASCII)));
@@ -156,7 +160,7 @@ public class RotatingSaltProviderTest {
         assertEquals(2, saltsProvider.getVersion(loadedMetadata));
 
         final ISaltProvider.ISaltSnapshot snapshot = saltsProvider.getSnapshot(Instant.now());
-        assertEquals(FIRST_LEVEL_SALT, snapshot.getFirstLevelSalt());
+        assertEquals(firstLevelSalt, snapshot.getFirstLevelSalt());
         assertTrue(snapshot.getModifiedSince(Instant.now().minus(1, ChronoUnit.HOURS)).isEmpty());
         assertEquals(1, snapshot.getModifiedSince(Instant.now().minus(30, ChronoUnit.HOURS)).size());
         assertEquals(1000002, snapshot.getModifiedSince(Instant.now().minus(30, ChronoUnit.HOURS)).get(0).id());
@@ -164,9 +168,9 @@ public class RotatingSaltProviderTest {
 
     @Test
     public void loadSaltMultipleVersionsExpired() throws Exception {
-        final String FIRST_LEVEL_SALT = "first_level_salt_value";
-        final String ID_PREFIX = "a";
-        final String ID_SECRET = "m3yMIcbg9vCaFLJsn4m4PfruZnvAZ72OxmFG5QsGMOw=";
+        final String firstLevelSalt = "first_level_salt_value";
+        final String idPrefix = "a";
+        final String idSecret = "m3yMIcbg9vCaFLJsn4m4PfruZnvAZ72OxmFG5QsGMOw=";
 
         final Instant generatedTimeV1 = Instant.now().minus(3, ChronoUnit.DAYS);
         final Instant expireTimeV1 = Instant.now().minus(2, ChronoUnit.DAYS);
@@ -177,9 +181,9 @@ public class RotatingSaltProviderTest {
         {
             metadataJson.put("version", 2);
             metadataJson.put("generated", generatedTimeV1.getEpochSecond() * 1000L);
-            metadataJson.put("first_level", FIRST_LEVEL_SALT);
-            metadataJson.put("id_prefix", ID_PREFIX);
-            metadataJson.put("id_secret", ID_SECRET);
+            metadataJson.put("first_level", firstLevelSalt);
+            metadataJson.put("id_prefix", idPrefix);
+            metadataJson.put("id_secret", idSecret);
             final JsonArray saltsRefList = new JsonArray();
             {
                 final JsonObject saltsRef = new JsonObject();
@@ -201,27 +205,30 @@ public class RotatingSaltProviderTest {
         }
 
         final String effectiveTimeStringV1 = String.valueOf(generatedTimeV1.getEpochSecond() * 1000L);
+        final String refreshFromTimeStringV1 = String.valueOf(generatedTimeV1.plus(30, ChronoUnit.DAYS).getEpochSecond() * 1000L);
+        final String effectiveTimeStringV2 = String.valueOf(generatedTimeV2.getEpochSecond() * 1000L);
+        final String refreshFromTimeStringV2 = String.valueOf(generatedTimeV2.plus(60, ChronoUnit.DAYS).getEpochSecond() * 1000L);
+
         final String saltsV1 =
-                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=\n" +
-                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=\n" +
-                        "1000002," + effectiveTimeStringV1 + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=\n" +
-                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=\n" +
-                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=\n" +
-                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=\n" +
-                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=\n" +
-                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=";
+                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000002," + effectiveTimeStringV1 + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV1 + ",\n" +
+                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV1 + ",";
 
         // update key 1000002
-        final String effectiveTimeStringV2 = String.valueOf(generatedTimeV2.getEpochSecond() * 1000L);
         final String saltsV2 =
-                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=\n" +
-                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=\n" +
-                        "1000002," + effectiveTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=\n" +
-                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=\n" +
-                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=\n" +
-                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=\n" +
-                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=\n" +
-                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=";
+                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000002," + effectiveTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=," + refreshFromTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=\n" +
+                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV2 + ",\n" +
+                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV2 + ",";
 
         when(cloudStorage.download("metadata"))
                 .thenReturn(new ByteArrayInputStream(metadataJson.toString().getBytes(StandardCharsets.US_ASCII)));
@@ -238,7 +245,7 @@ public class RotatingSaltProviderTest {
         assertEquals(2, saltsProvider.getVersion(loadedMetadata));
 
         final ISaltProvider.ISaltSnapshot snapshot = saltsProvider.getSnapshot(Instant.now());
-        assertEquals(FIRST_LEVEL_SALT, snapshot.getFirstLevelSalt());
+        assertEquals(firstLevelSalt, snapshot.getFirstLevelSalt());
         assertTrue(snapshot.getModifiedSince(Instant.now().minus(1, ChronoUnit.HOURS)).isEmpty());
         assertEquals(1, snapshot.getModifiedSince(Instant.now().minus(49, ChronoUnit.HOURS)).size());
         assertEquals(1000002, snapshot.getModifiedSince(Instant.now().minus(49, ChronoUnit.HOURS)).get(0).id());

--- a/src/test/java/com/uid2/shared/store/RotatingSaltProviderTest.java
+++ b/src/test/java/com/uid2/shared/store/RotatingSaltProviderTest.java
@@ -20,12 +20,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class RotatingSaltProviderTest {
+class RotatingSaltProviderTest {
     @Mock
     private ICloudStorage cloudStorage;
 
     @Test
-    public void loadSaltSingleVersion() throws Exception {
+    void loadSaltSingleVersion() throws Exception {
         final String firstLevelSalt = "first_level_salt_value";
         final String idPrefix = "a";
         final String idSecret = "m3yMIcbg9vCaFLJsn4m4PfruZnvAZ72OxmFG5QsGMOw=";
@@ -55,14 +55,14 @@ public class RotatingSaltProviderTest {
         final String effectiveTimeString = String.valueOf(generatedTime.getEpochSecond() * 1000L);
         final String refreshFromTimeString = String.valueOf(generatedTime.plus(30, ChronoUnit.DAYS).getEpochSecond() * 1000L);
         final String salts =
-                "1000000," + effectiveTimeString + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeString + ",\n" +
-                        "1000001," + effectiveTimeString + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeString + ",\n" +
-                        "1000002," + effectiveTimeString + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=," + refreshFromTimeString + ",\n" +
-                        "1000003," + effectiveTimeString + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeString + ",\n" +
-                        "1000004," + effectiveTimeString + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeString + ",\n" +
-                        "1000005," + effectiveTimeString + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeString + ",\n" +
-                        "1000006," + effectiveTimeString + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeString + ",\n" +
-                        "1000007," + effectiveTimeString + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeString + ",";
+                "1000000," + effectiveTimeString + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeString + ",,,,,,\n" +
+                        "1000001," + effectiveTimeString + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeString + ",,,,,,\n" +
+                        "1000002," + effectiveTimeString + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=," + refreshFromTimeString + ",,,,,,\n" +
+                        "1000003," + effectiveTimeString + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeString + ",,,,,,\n" +
+                        "1000004," + effectiveTimeString + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeString + ",,,,,,\n" +
+                        "1000005," + effectiveTimeString + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeString + ",,,,,,\n" +
+                        "1000006," + effectiveTimeString + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeString + ",,,,,,\n" +
+                        "1000007," + effectiveTimeString + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeString + ",,,,,,";
 
         when(cloudStorage.download("metadata"))
                 .thenReturn(new ByteArrayInputStream(metadataJson.toString().getBytes(StandardCharsets.US_ASCII)));
@@ -82,7 +82,7 @@ public class RotatingSaltProviderTest {
     }
 
     @Test
-    public void loadSaltMultipleVersions() throws Exception {
+    void loadSaltMultipleVersions() throws Exception {
         final String firstLevelSalt = "first_level_salt_value";
         final String idPrefix = "a";
         final String idSecret = "m3yMIcbg9vCaFLJsn4m4PfruZnvAZ72OxmFG5QsGMOw=";
@@ -125,25 +125,25 @@ public class RotatingSaltProviderTest {
         final String refreshFromTimeStringV2 = String.valueOf(generatedTimeV2.plus(60, ChronoUnit.DAYS).getEpochSecond() * 1000L);
 
         final String saltsV1 =
-                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000002," + effectiveTimeStringV1 + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV1 + ",";
+                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000002," + effectiveTimeStringV1 + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV1 + ",,,,,,";
 
         // update key 1000002
         final String saltsV2 =
-                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000002," + effectiveTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=," + refreshFromTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=\n" +
-                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV2 + ",";
+                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000002," + effectiveTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=," + refreshFromTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=,,,,,\n" +
+                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV2 + ",,,,,,";
 
         when(cloudStorage.download("metadata"))
                 .thenReturn(new ByteArrayInputStream(metadataJson.toString().getBytes(StandardCharsets.US_ASCII)));
@@ -167,7 +167,7 @@ public class RotatingSaltProviderTest {
     }
 
     @Test
-    public void loadSaltMultipleVersionsExpired() throws Exception {
+    void loadSaltMultipleVersionsExpired() throws Exception {
         final String firstLevelSalt = "first_level_salt_value";
         final String idPrefix = "a";
         final String idSecret = "m3yMIcbg9vCaFLJsn4m4PfruZnvAZ72OxmFG5QsGMOw=";
@@ -210,25 +210,25 @@ public class RotatingSaltProviderTest {
         final String refreshFromTimeStringV2 = String.valueOf(generatedTimeV2.plus(60, ChronoUnit.DAYS).getEpochSecond() * 1000L);
 
         final String saltsV1 =
-                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000002," + effectiveTimeStringV1 + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV1 + ",\n" +
-                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV1 + ",";
+                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000002," + effectiveTimeStringV1 + ",+a5LPajo7uPfNcc9HH0Tn25b3RnSNZwe8YaAKcyeHaA=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV1 + ",,,,,,\n" +
+                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV1 + ",,,,,,";
 
         // update key 1000002
         final String saltsV2 =
-                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000002," + effectiveTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=," + refreshFromTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=\n" +
-                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV2 + ",\n" +
-                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV2 + ",";
+                "1000000," + effectiveTimeStringV1 + ",y5YitNf/KFtceipDz8nqsFVmBZsK3KY7s8bOVM4gMD4=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000001," + effectiveTimeStringV1 + ",z1uBoGyyzgna9i0o/r5eiD/wAhDX/2Q/6zX1p6hsF7I=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000002," + effectiveTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=," + refreshFromTimeStringV2 + ",AP73KwZscb1ltQQH/B7fdbHUnMmbJNlRULxzklXUqaA=,,,,,\n" +
+                        "1000003," + effectiveTimeStringV1 + ",wAL6U+lu9gcMhSEySzWG9RQyoo446zAyGWKTW8VVoVw=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000004," + effectiveTimeStringV1 + ",eP9ZvW4igLQZ4QfzlyiXgKYFDZgmGOefaKDLEL0zuwE=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000005," + effectiveTimeStringV1 + ",UebesrNN0bQkm/QR7Jx7eav+UDXN5Gbq3zs1fLBMRy0=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000006," + effectiveTimeStringV1 + ",MtpALOziEJMtPlCQHk6RHALuWvRvRZpCDBmO0xPAia0=," + refreshFromTimeStringV2 + ",,,,,,\n" +
+                        "1000007," + effectiveTimeStringV1 + ",7tjv+KXaSztTZHEHULacotHQ7IpGBcw6IymoRLObkT4=," + refreshFromTimeStringV2 + ",,,,,,";
 
         when(cloudStorage.download("metadata"))
                 .thenReturn(new ByteArrayInputStream(metadataJson.toString().getBytes(StandardCharsets.US_ASCII)));
@@ -250,6 +250,4 @@ public class RotatingSaltProviderTest {
         assertEquals(1, snapshot.getModifiedSince(Instant.now().minus(49, ChronoUnit.HOURS)).size());
         assertEquals(1000002, snapshot.getModifiedSince(Instant.now().minus(49, ChronoUnit.HOURS)).get(0).id());
     }
-
-
 }

--- a/src/test/java/com/uid2/shared/store/salt/SaltFileParserTest.java
+++ b/src/test/java/com/uid2/shared/store/salt/SaltFileParserTest.java
@@ -87,7 +87,7 @@ class SaltFileParserTest {
         var file = """
 1,100,salt1,1000,old_salt1,10,key_1,key_salt_1,100,old_key_1,old_key_1_salt
 2,200,salt2,2000,old_salt2,20
-3,300,salt3,3000
+3,300,salt3,3000,
 """;
         SaltEntry[] actual = parser.parseFile(file, 3);
 
@@ -97,7 +97,7 @@ class SaltFileParserTest {
                         new KeyMaterial(100, "old_key_1", "old_key_1_salt")
                 ),
                 new SaltEntry(2, hashed2, 200, "salt2", 2000L, "old_salt2",null, null),
-                new SaltEntry(3, hashed3, 300, "salt3", null, null,null, null)
+                new SaltEntry(3, hashed3, 300, "salt3", 3000L, null,null, null)
         };
 
         assertThat(actual).isEqualTo(expected);

--- a/src/test/java/com/uid2/shared/store/salt/SaltFileParserTest.java
+++ b/src/test/java/com/uid2/shared/store/salt/SaltFileParserTest.java
@@ -16,22 +16,6 @@ class SaltFileParserTest {
     private final String hashed3 = hashingScheme.encode(3);
 
     @Test
-    void parsesSaltFileWithMinimalFields() {
-        var file = """
-1,100,salt1,1000,old_salt1
-2,200,salt2,2000,
-""";
-        SaltEntry[] actual = parser.parseFile(file, 2);
-
-        SaltEntry[] expected = new SaltEntry[]{
-                new SaltEntry(1, hashed1, 100, "salt1", 1000L, "old_salt1", null, null),
-                new SaltEntry(2, hashed2, 200, "salt2", 2000L, null, null, null)
-        };
-
-        assertThat(actual).isEqualTo(expected);
-    }
-
-    @Test
     void parsesSaltFileWithAllFields() {
         var file = """
 1,100,salt1,1000,old_salt1,10,key_1,key_salt_1,100,old_key_1,old_key_1_salt
@@ -53,6 +37,27 @@ class SaltFileParserTest {
     }
 
     @Test
+    void parsesSaltFileWithNullValuesForOptionalFields() {
+        var file = """
+1,100,salt1,1000,,10,key_1,key_salt_1,,,
+2,200,salt2,2000,,20,key_2,key_salt_2,,,
+""";
+        SaltEntry[] actual = parser.parseFile(file, 2);
+
+        SaltEntry[] expected = new SaltEntry[]{
+                new SaltEntry(1, hashed1, 100, "salt1", 1000L, null,
+                        new KeyMaterial(10, "key_1", "key_salt_1"),
+                        null
+                ),
+                new SaltEntry(2, hashed2, 200, "salt2", 2000L, null,
+                        new KeyMaterial(20, "key_2", "key_salt_2"),
+                        null
+                )
+        };
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
     void parsesSaltFileWithNullValuesForKeyFields() {
         var file = """
 1,100,salt1,1000,old_salt1,,,,,,
@@ -64,42 +69,6 @@ class SaltFileParserTest {
                 new SaltEntry(1, hashed1, 100, "salt1", 1000L, "old_salt1",null, null),
                 new SaltEntry(2, hashed2, 200, "salt2", 2000L, null,null, null)
         };
-        assertThat(actual).isEqualTo(expected);
-    }
-
-    @Test
-    void parsesSaltFileWithoutEncryptionKeyFields() {
-        var file = """
-1,100,salt1,1000,old_salt1,10
-2,200,salt2,2000,,20
-""";
-        SaltEntry[] actual = parser.parseFile(file, 2);
-
-        SaltEntry[] expected = new SaltEntry[]{
-                new SaltEntry(1, hashed1, 100, "salt1", 1000L, "old_salt1", null, null),
-                new SaltEntry(2, hashed2, 200, "salt2", 2000L, null,null, null)
-        };
-        assertThat(actual).isEqualTo(expected);
-    }
-
-    @Test
-    void canMixDifferentFieldsPresenceInSameFile() {
-        var file = """
-1,100,salt1,1000,old_salt1,10,key_1,key_salt_1,100,old_key_1,old_key_1_salt
-2,200,salt2,2000,old_salt2,20
-3,300,salt3,3000,
-""";
-        SaltEntry[] actual = parser.parseFile(file, 3);
-
-        SaltEntry[] expected = new SaltEntry[]{
-                new SaltEntry(1, hashed1, 100, "salt1", 1000L, "old_salt1",
-                        new KeyMaterial(10, "key_1", "key_salt_1"),
-                        new KeyMaterial(100, "old_key_1", "old_key_1_salt")
-                ),
-                new SaltEntry(2, hashed2, 200, "salt2", 2000L, "old_salt2",null, null),
-                new SaltEntry(3, hashed3, 300, "salt3", 3000L, null,null, null)
-        };
-
         assertThat(actual).isEqualTo(expected);
     }
 }

--- a/src/test/java/com/uid2/shared/store/salt/SaltFileParserTest.java
+++ b/src/test/java/com/uid2/shared/store/salt/SaltFileParserTest.java
@@ -18,14 +18,14 @@ class SaltFileParserTest {
     @Test
     void parsesSaltFileWithMinimalFields() {
         var file = """
-1,100,salt1
-2,200,salt2
+1,100,salt1,1000,old_salt1
+2,200,salt2,2000,old_salt2
 """;
         SaltEntry[] actual = parser.parseFile(file, 2);
 
         SaltEntry[] expected = new SaltEntry[]{
-                new SaltEntry(1, hashed1, 100, "salt1", null, null, null, null),
-                new SaltEntry(2, hashed2, 200, "salt2", null, null, null, null)
+                new SaltEntry(1, hashed1, 100, "salt1", 1000L, "old_salt1", null, null),
+                new SaltEntry(2, hashed2, 200, "salt2", 2000L, "old_salt2", null, null)
         };
 
         assertThat(actual).isEqualTo(expected);
@@ -48,21 +48,6 @@ class SaltFileParserTest {
                         new KeyMaterial(20, "key_2", "key_salt_2"),
                         new KeyMaterial(200, "old_key_2", "old_key_2_salt")
                 )
-        };
-        assertThat(actual).isEqualTo(expected);
-    }
-
-    @Test
-    void parsesSaltFileWithNullValuesForNewFields() {
-        var file = """
-1,100,salt1,,,,,,,,
-2,200,salt2,,,,,,,,
-""";
-        SaltEntry[] actual = parser.parseFile(file, 2);
-
-        SaltEntry[] expected = new SaltEntry[]{
-                new SaltEntry(1, hashed1, 100, "salt1", null, null,null, null),
-                new SaltEntry(2, hashed2, 200, "salt2", null, null,null, null)
         };
         assertThat(actual).isEqualTo(expected);
     }
@@ -115,5 +100,6 @@ class SaltFileParserTest {
                 new SaltEntry(3, hashed3, 300, "salt3", null, null,null, null)
         };
 
+        assertThat(actual).isEqualTo(expected);
     }
 }

--- a/src/test/java/com/uid2/shared/store/salt/SaltFileParserTest.java
+++ b/src/test/java/com/uid2/shared/store/salt/SaltFileParserTest.java
@@ -19,13 +19,13 @@ class SaltFileParserTest {
     void parsesSaltFileWithMinimalFields() {
         var file = """
 1,100,salt1,1000,old_salt1
-2,200,salt2,2000,old_salt2
+2,200,salt2,2000,
 """;
         SaltEntry[] actual = parser.parseFile(file, 2);
 
         SaltEntry[] expected = new SaltEntry[]{
                 new SaltEntry(1, hashed1, 100, "salt1", 1000L, "old_salt1", null, null),
-                new SaltEntry(2, hashed2, 200, "salt2", 2000L, "old_salt2", null, null)
+                new SaltEntry(2, hashed2, 200, "salt2", 2000L, null, null, null)
         };
 
         assertThat(actual).isEqualTo(expected);
@@ -56,13 +56,13 @@ class SaltFileParserTest {
     void parsesSaltFileWithNullValuesForKeyFields() {
         var file = """
 1,100,salt1,1000,old_salt1,,,,,,
-2,200,salt2,2000,old_salt2,,,,,,
+2,200,salt2,2000,,,,,,,
 """;
         SaltEntry[] actual = parser.parseFile(file, 2);
 
         SaltEntry[] expected = new SaltEntry[]{
                 new SaltEntry(1, hashed1, 100, "salt1", 1000L, "old_salt1",null, null),
-                new SaltEntry(2, hashed2, 200, "salt2", 2000L, "old_salt2",null, null)
+                new SaltEntry(2, hashed2, 200, "salt2", 2000L, null,null, null)
         };
         assertThat(actual).isEqualTo(expected);
     }
@@ -71,13 +71,13 @@ class SaltFileParserTest {
     void parsesSaltFileWithoutEncryptionKeyFields() {
         var file = """
 1,100,salt1,1000,old_salt1,10
-2,200,salt2,2000,old_salt2,20
+2,200,salt2,2000,,20
 """;
         SaltEntry[] actual = parser.parseFile(file, 2);
 
         SaltEntry[] expected = new SaltEntry[]{
                 new SaltEntry(1, hashed1, 100, "salt1", 1000L, "old_salt1", null, null),
-                new SaltEntry(2, hashed2, 200, "salt2", 2000L, "old_salt2",null, null)
+                new SaltEntry(2, hashed2, 200, "salt2", 2000L, null,null, null)
         };
         assertThat(actual).isEqualTo(expected);
     }


### PR DESCRIPTION
`SaltFileParserTest` has been updated such that `refreshFrom` field has a value present in all cases, and `previousSalt` has an empty-string value in the test data

Updated `uid2-shared` locally across the following repos and ran E2Es:
* `uid2-admin`
* `uid2-core`
* `uid2-operator`
* `uid2-optout`
* `uid2-snowflake`