### PR TITLE
UID2-7251: upgrade netty to 4.1.133.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <vertx.version>4.5.21</vertx.version>
         <!-- check micrometer.version vertx-micrometer-metrics consumes before bumping up -->
         <micrometer.version>1.12.2</micrometer.version>
-        <netty.version>4.1.132.Final</netty.version>
+        <netty.version>4.1.133.Final</netty.version>
         <image.version>${project.version}</image.version>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
## Summary

Bumps the netty BOM (`netty.version` property) from **4.1.132.Final → 4.1.133.Final** to resolve 4 HIGH-severity Trivy findings in the netty codec modules. uid2-shared has no vuln-scan Slack notify workflow, so these weren't auto-alerted — raised manually by the team in #dev-uid2-core.

## Vulnerabilities (all HIGH, fixed in 4.1.133.Final)

| CVE | Module |
|-----|--------|
| CVE-2026-42583 | io.netty:netty-codec |
| CVE-2026-42579 | io.netty:netty-codec-dns (improper DNS domain name constraint) |
| CVE-2026-42584 | io.netty:netty-codec-http (incorrect HTTP response parsing) |
| CVE-2026-42587 | io.netty:netty-codec-http / -http2 (DoS via unbounded memory allocation) |

## Change

- `<netty.version>` `4.1.132.Final` → `4.1.133.Final`. netty is managed via the imported `netty-bom`, so this one property pins every codec module. netty is transitive via vertx 4.5.21 and azure-core-http-netty.

## Verification

- `mvn dependency:tree`: all flagged codec modules now resolve to 4.1.133.Final.
- `mvn test`: **476 tests, 0 failures**.

Jira: https://thetradedesk.atlassian.net/browse/UID2-7251

🤖 Generated with [Claude Code](https://claude.com/claude-code)