### PR TITLE
UID2-7251: bump netty to 4.1.135.Final to fix 4 HIGH CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <vertx.version>4.5.21</vertx.version>
         <!-- check micrometer.version vertx-micrometer-metrics consumes before bumping up -->
         <micrometer.version>1.12.2</micrometer.version>
-        <netty.version>4.1.133.Final</netty.version>
+        <netty.version>4.1.135.Final</netty.version>
         <image.version>${project.version}</image.version>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
## What

Bumps `netty.version` from `4.1.133.Final` → `4.1.135.Final`.

## Why

PR #614 bumped netty to `4.1.133.Final`, but the 4 HIGH netty CVEs flagged by Trivy in the operator publish are only fixed in `4.1.135.Final`:

| Library | CVE |
|---------|-----|
| `io.netty:netty-handler` | CVE-2026-44249, CVE-2026-45416 |
| `io.netty:netty-resolver-dns` | CVE-2026-45674, CVE-2026-47691 |

This keeps uid2-shared aligned with the operator's netty pin (operator fix: IABTechLab/uid2-operator#2593).

**Note:** uid2-operator pins netty independently of uid2-shared, so this change alone does not affect the operator build until uid2-shared is released and the operator's `uid2-shared.version` is bumped to pick it up. The operator PR is what unblocks the failing scan.

## Verification

- `mvn dependency:tree -Dincludes=io.netty` → all `netty-4.1.x` artifacts resolve to `4.1.135.Final`.
- `mvn clean compile` → BUILD SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)