### PR TITLE
UID2-7105: parse salt files line-by-line to avoid String[] buffer

### DIFF
--- a/src/main/java/com/uid2/shared/store/salt/EncryptedRotatingSaltProvider.java
+++ b/src/main/java/com/uid2/shared/store/salt/EncryptedRotatingSaltProvider.java
@@ -5,8 +5,10 @@ import com.uid2.shared.model.SaltEntry;
 import com.uid2.shared.store.reader.RotatingCloudEncryptionKeyProvider;
 import com.uid2.shared.store.scope.StoreScope;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringReader;
 
 import static com.uid2.shared.util.CloudEncryptionHelpers.decryptInputStream;
 
@@ -21,6 +23,8 @@ public class EncryptedRotatingSaltProvider extends RotatingSaltProvider {
     @Override
     protected SaltEntry[] readInputStream(InputStream inputStream, SaltFileParser saltFileParser, Integer size) throws IOException {
         String decrypted = decryptInputStream(inputStream, cloudEncryptionKeyProvider, "salts");
-        return saltFileParser.parseFile(decrypted, size);
+        try (BufferedReader reader = new BufferedReader(new StringReader(decrypted))) {
+            return saltFileParser.parseLines(reader, size);
+        }
     }
 }

--- a/src/main/java/com/uid2/shared/store/salt/RotatingSaltProvider.java
+++ b/src/main/java/com/uid2/shared/store/salt/RotatingSaltProvider.java
@@ -141,8 +141,7 @@ public class RotatingSaltProvider implements ISaltProvider, IMetadataVersionedSt
 
     protected SaltEntry[] readInputStream(InputStream inputStream, SaltFileParser saltFileParser, Integer size) throws IOException {
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))) {
-            String[] saltFileLines = reader.lines().toArray(String[]::new);
-            return saltFileParser.parseFileLines(saltFileLines, size);
+            return saltFileParser.parseLines(reader, size);
         }
     }
 

--- a/src/main/java/com/uid2/shared/store/salt/SaltFileParser.java
+++ b/src/main/java/com/uid2/shared/store/salt/SaltFileParser.java
@@ -2,11 +2,25 @@ package com.uid2.shared.store.salt;
 
 import com.uid2.shared.model.SaltEntry;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+
 public class SaltFileParser {
     private final IdHashingScheme idHashingScheme;
 
     public SaltFileParser(IdHashingScheme idHashingScheme) {
         this.idHashingScheme = idHashingScheme;
+    }
+
+    public SaltEntry[] parseLines(BufferedReader reader, Integer size) throws IOException {
+        SaltEntry[] entries = new SaltEntry[size];
+        int lineNumber = 0;
+        String line;
+        while ((line = reader.readLine()) != null) {
+            entries[lineNumber] = parseLine(line, lineNumber);
+            lineNumber++;
+        }
+        return entries;
     }
 
     public SaltEntry[] parseFile(String saltFileContent, Integer size) {

--- a/src/test/java/com/uid2/shared/store/salt/SaltFileParserTest.java
+++ b/src/test/java/com/uid2/shared/store/salt/SaltFileParserTest.java
@@ -4,6 +4,9 @@ import com.uid2.shared.model.SaltEntry;
 import com.uid2.shared.model.SaltEntry.KeyMaterial;
 import org.junit.jupiter.api.Test;
 
+import java.io.BufferedReader;
+import java.io.StringReader;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 class SaltFileParserTest {
@@ -16,6 +19,18 @@ class SaltFileParserTest {
     private final String hashed3 = hashingScheme.encode(3);
     private final String hashed4 = hashingScheme.encode(4);
     private final String hashed5 = hashingScheme.encode(5);
+
+    @Test
+    void parseLinesMatchesParseFile() throws Exception {
+        var file = """
+1,100,salt1,1000,old_salt1,10,key_1,key_salt_1,100,old_key_1,old_key_1_salt
+2,200,salt2,2000,old_salt2,20,key_2,key_salt_2,200,old_key_2,old_key_2_salt
+""";
+        SaltEntry[] viaParseFile = parser.parseFile(file, 2);
+        SaltEntry[] viaParseLines = parser.parseLines(new BufferedReader(new StringReader(file)), 2);
+
+        assertThat(viaParseLines).isEqualTo(viaParseFile);
+    }
 
     @Test
     void parsesSaltFileWithAllFields() {


### PR DESCRIPTION
## Why

`RotatingSaltProvider.readInputStream` called `reader.lines().toArray(String[]::new)` before parsing, which materialised the entire salt file as a `String[]` of ~1M objects. For a 99 MB snapshot this creates ~147 MB of temporary strings on the heap simultaneously with the ~180 MB `SaltEntry[]` being built — a ~327 MB peak per snapshot load that is pure overhead.

`EncryptedRotatingSaltProvider` had a related issue: it called `saltFileParser.parseFile(decrypted, size)` which internally calls `String.split("\n")`, creating another large `String[]` from the already-decrypted string.

## What changed

- Added `SaltFileParser.parseLines(BufferedReader, Integer)` — reads line-by-line from the reader, parsing directly into a pre-sized `SaltEntry[]` with no intermediate array.
- `RotatingSaltProvider.readInputStream` now calls `parseLines` directly instead of `toArray` + `parseFileLines`.
- `EncryptedRotatingSaltProvider.readInputStream` wraps the decrypted string in a `StringReader`/`BufferedReader` and calls `parseLines`, avoiding the `split("\n")` allocation.
- Existing `parseFile`/`parseFileLines` methods are unchanged (other callers unaffected).

## Memory impact

Per snapshot load: peak drops from ~327 MB to ~180 MB (the `SaltEntry[]` itself, which is irreducible). With 2 snapshots, worst-case overlap drops from ~507 MB to ~360 MB.

## Testing

- Added `SaltFileParserTest.parseLinesMatchesParseFile` to verify `parseLines` produces identical output to `parseFile` for the same input.
- All existing `SaltFileParserTest`, `RotatingSaltProviderTest`, and `EncryptedRotatingSaltProviderTest` tests pass (13 total, 0 failures).

Part of UID2-7105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)