### PR TITLE
bump central-publishing-maven-plugin to 0.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -374,7 +374,7 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.7.0</version>
+                <version>0.11.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>


### PR DESCRIPTION
bump central-publishing-maven-plugin to 0.11.0 to fix publish deserialization error

Sonatype Central API added a "warnings" field to DeploymentApiResponse; 0.7.0's Jackson model didn't declare it, causing UnrecognizedPropertyException on publish.
example: https://github.com/IABTechLab/uid2-shared/actions/runs/27809662117/job/82298647209