### PR TITLE
UID2-7364: Revert jackson-databind to 2.14.2 (downstream breakage)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -6,7 +6,9 @@
 # See: UID2-6670
 GHSA-72hv-8253-57qq exp:2026-09-01
 
-# jackson-databind data-binding vulnerability - no upstream fix released yet (fix targets: 2.18.8, 2.21.4, 3.1.4)
+# jackson-databind polymorphic deserialization bypass - not exploitable, uid2-shared does not enable polymorphic
+# typing (no @JsonTypeInfo, enableDefaultTyping, or PolymorphicTypeValidator usage). No upstream fix released yet
+# (fix targets: 2.18.8, 2.21.4, 3.1.4; latest available: 2.18.4).
 # See: UID2-7364
 CVE-2026-54512 exp:2026-07-25
 CVE-2026-54513 exp:2026-07-25

--- a/pom.xml
+++ b/pom.xml
@@ -208,13 +208,8 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.19.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.19.0</version>
+            <version>2.14.2</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
## Summary

Reverts the jackson-databind version from 2.19.0 back to 2.14.2. The upgrade in #631 caused breakage in other services that consume this shared jar.

The `.trivyignore` suppression for CVE-2026-54512 / CVE-2026-54513 (added in #631) is kept in place — no upstream fix is released yet, so the scan will pass regardless of version.

## Changes

- `pom.xml`: revert `jackson-databind` 2.19.0 → 2.14.2; remove the `jackson-core` 2.19.0 explicit pin (was only needed to resolve a conflict with 2.19.0)

Jira: [UID2-7364](https://thetradedesk.atlassian.net/browse/UID2-7364)